### PR TITLE
feat: enrich wrapped pages with Spotify artist and album art images

### DIFF
--- a/scripts/enrich-wrapped-images.mjs
+++ b/scripts/enrich-wrapped-images.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+/**
+ * Enriches wrapped year JSON files with Spotify image URLs.
+ *
+ * For each year in src/data/wrapped/YYYY.json that uses source=extended_history
+ * and lacks image data, this script:
+ *   - Looks up each top artist by name via the Spotify search API → adds image URL
+ *   - Looks up each top track by its stored Spotify URI → adds albumArt URL
+ *   - Writes the results into apiSnapshot.topArtists / apiSnapshot.topTracks
+ *
+ * The [year].astro page merges these image fields at build time via the
+ * apiSnapshot mechanism, so no component changes are needed.
+ *
+ * Usage:
+ *   SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=... SPOTIFY_REFRESH_TOKEN=... \
+ *     node scripts/enrich-wrapped-images.mjs [year]
+ *
+ * If [year] is omitted, all years are processed.
+ *
+ * Environment variables required:
+ *   SPOTIFY_CLIENT_ID
+ *   SPOTIFY_CLIENT_SECRET
+ *   SPOTIFY_REFRESH_TOKEN
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = resolve(__dirname, "../src/data/wrapped");
+
+const { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET, SPOTIFY_REFRESH_TOKEN } =
+  process.env;
+
+if (!SPOTIFY_CLIENT_ID || !SPOTIFY_CLIENT_SECRET || !SPOTIFY_REFRESH_TOKEN) {
+  console.error(
+    "Missing required environment variables: SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET, SPOTIFY_REFRESH_TOKEN"
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+/**
+ * Get a user OAuth token (refresh_token flow). Used for artist search.
+ */
+async function getUserToken() {
+  const credentials = Buffer.from(
+    `${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`
+  ).toString("base64");
+
+  const res = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: SPOTIFY_REFRESH_TOKEN,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Token refresh failed (${res.status}): ${text}`);
+  }
+
+  const data = await res.json();
+  return data.access_token;
+}
+
+/**
+ * Get a client credentials token. Works for public catalog lookups
+ * (search by track name/artist, album art, etc.) without user context.
+ */
+async function getClientToken() {
+  const credentials = Buffer.from(
+    `${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`
+  ).toString("base64");
+
+  const res = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ grant_type: "client_credentials" }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Client credentials token failed (${res.status}): ${text}`);
+  }
+
+  const data = await res.json();
+  return data.access_token;
+}
+
+// ---------------------------------------------------------------------------
+// Spotify helpers
+// ---------------------------------------------------------------------------
+
+function pickImage(images) {
+  if (!images || images.length === 0) return "";
+  return images.find((img) => img.width === 640)?.url || images[0]?.url || "";
+}
+
+async function spotifyGet(url, accessToken) {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (res.status === 429) {
+    const retryAfter = parseInt(res.headers.get("Retry-After") ?? "30", 10);
+    if (retryAfter > 300) {
+      // Daily quota exhausted — not worth waiting. Throw so the caller records
+      // an empty result and we move on rather than blocking for hours.
+      throw new Error(
+        `Spotify API error (429): daily quota exhausted (Retry-After: ${retryAfter}s). ` +
+          `Re-run this script tomorrow to fill in remaining images.`
+      );
+    }
+    // Short-term rate limit — wait and retry once.
+    console.log(`\n  Rate limited — waiting ${retryAfter}s before retry...`);
+    await new Promise((r) => setTimeout(r, retryAfter * 1000));
+    return spotifyGet(url, accessToken);
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Spotify API error (${res.status}): ${text}`);
+  }
+  return res.json();
+}
+
+/** Search for an artist by exact name, return the best-match image URL. */
+async function lookupArtistImage(name, accessToken) {
+  const query = encodeURIComponent(name);
+  const data = await spotifyGet(
+    `https://api.spotify.com/v1/search?q=${query}&type=artist&limit=5`,
+    accessToken
+  );
+  const artists = data.artists?.items ?? [];
+  // Prefer exact name match (case-insensitive)
+  const exact = artists.find(
+    (a) => a.name.toLowerCase() === name.toLowerCase()
+  );
+  const pick = exact || artists[0];
+  if (!pick) return { image: "", url: "" };
+  return {
+    image: pickImage(pick.images),
+    url: pick.external_urls?.spotify || "",
+  };
+}
+
+/**
+ * Search for a track by name + artist using the Spotify search API.
+ * Returns { albumArt, url } for the best match.
+ *
+ * Note: The /v1/tracks batch endpoint requires a market parameter and returns
+ * 403 with user-scoped tokens. Search works reliably with both token types.
+ */
+async function lookupTrackImage(name, artist, accessToken) {
+  const q = encodeURIComponent(`track:${name} artist:${artist}`);
+  const data = await spotifyGet(
+    `https://api.spotify.com/v1/search?q=${q}&type=track&limit=5`,
+    accessToken
+  );
+  const tracks = data.tracks?.items ?? [];
+  // Prefer exact match on both track name and artist (case-insensitive)
+  const nameLower = name.toLowerCase();
+  const artistLower = artist.toLowerCase();
+  const exact = tracks.find(
+    (t) =>
+      t.name.toLowerCase() === nameLower &&
+      t.artists.some((a) => a.name.toLowerCase() === artistLower)
+  );
+  const pick = exact || tracks[0];
+  if (!pick) return { albumArt: "", url: "" };
+  return {
+    albumArt: pickImage(pick.album?.images ?? []),
+    url: pick.external_urls?.spotify || "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-year enrichment
+// ---------------------------------------------------------------------------
+
+async function enrichYear(filePath, accessToken) {
+  const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+
+  if (raw.source !== "extended_history") {
+    console.log(`  Skipping (source=${raw.source})`);
+    return;
+  }
+
+  const topArtists = raw.topArtists ?? raw.artists ?? [];
+  const topTracks = raw.topTracks ?? raw.tracks ?? [];
+
+  if (topArtists.length === 0 && topTracks.length === 0) {
+    console.log("  No artists or tracks — nothing to enrich");
+    return;
+  }
+
+  // Check if already fully enriched. A year is considered complete when:
+  // - apiSnapshot.topArtists exists with images for all top artists, AND
+  // - apiSnapshot.topTracks exists with images for most tracks (>=80%)
+  // Partially enriched years (from a rate-limited run) are re-processed.
+  const snap = raw.apiSnapshot;
+  if (snap?.topArtists?.length > 0 && snap?.topTracks?.length > 0) {
+    const artistsComplete = snap.topArtists.every((a) => a.image);
+    const tracksWithArt = snap.topTracks.filter((t) => t.albumArt).length;
+    const tracksComplete = tracksWithArt / snap.topTracks.length >= 0.8;
+    if (artistsComplete && tracksComplete) {
+      console.log(
+        `  Already fully enriched (${snap.topArtists.length} artists, ${tracksWithArt}/${snap.topTracks.length} tracks) — skipping`
+      );
+      return;
+    }
+    console.log(
+      `  Partially enriched (artists: ${snap.topArtists.filter((a) => a.image).length}/${snap.topArtists.length}, tracks: ${tracksWithArt}/${snap.topTracks.length}) — re-enriching`
+    );
+  }
+
+  // --- Enrich artists ---
+  console.log(`  Looking up ${topArtists.length} artists...`);
+  const enrichedArtists = [];
+  for (const artist of topArtists) {
+    process.stdout.write(`    ${artist.name}...`);
+    try {
+      const { image, url } = await lookupArtistImage(artist.name, accessToken);
+      enrichedArtists.push({ name: artist.name, image, url });
+      console.log(image ? " got image" : " no image");
+    } catch (err) {
+      console.log(` error: ${err.message}`);
+      enrichedArtists.push({ name: artist.name, image: "", url: "" });
+    }
+    // Rate-limit courtesy pause (500ms keeps well under Spotify's ~180 req/min limit)
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  // --- Enrich tracks ---
+  // Use search by name+artist. The /v1/tracks batch endpoint returns 403 with
+  // the user-scoped token (only has user-top-read scope); search works fine.
+  console.log(`  Looking up ${topTracks.length} tracks via search...`);
+  const enrichedTracks = [];
+  let trackFound = 0;
+  for (const t of topTracks) {
+    process.stdout.write(`    ${t.name}...`);
+    try {
+      const { albumArt, url } = await lookupTrackImage(t.name, t.artist, accessToken);
+      enrichedTracks.push({
+        name: t.name,
+        artist: t.artist,
+        albumArt,
+        url: url || t.url || "",
+      });
+      if (albumArt) trackFound++;
+      console.log(albumArt ? " got image" : " no image");
+    } catch (err) {
+      console.log(` error: ${err.message}`);
+      enrichedTracks.push({ name: t.name, artist: t.artist, albumArt: "", url: t.url || "" });
+    }
+    // Rate-limit courtesy pause (500ms keeps well under Spotify's ~180 req/min limit)
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  console.log(`  Got album art for ${trackFound}/${topTracks.length} tracks`);
+
+  // Write apiSnapshot back into the file
+  const updated = {
+    ...raw,
+    apiSnapshot: {
+      topArtists: enrichedArtists,
+      topTracks: enrichedTracks,
+    },
+  };
+
+  writeFileSync(filePath, JSON.stringify(updated, null, 2) + "\n");
+  console.log(`  Written updated file.`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const targetYear = process.argv[2]; // optional: "2024"
+
+  // Use user token for artist search (works fine with user-top-read scope).
+  // Client credentials token also works for search but is only needed if
+  // the user token stops working for catalog lookups.
+  console.log("Refreshing Spotify access token...");
+  const accessToken = await getUserToken();
+  console.log("Token obtained.\n");
+
+  const files = readdirSync(DATA_DIR)
+    .filter((f) => /^\d{4}\.json$/.test(f))
+    .sort();
+
+  for (const file of files) {
+    const year = file.replace(".json", "");
+    if (targetYear && year !== targetYear) continue;
+
+    console.log(`Processing ${year}...`);
+    try {
+      await enrichYear(resolve(DATA_DIR, file), accessToken);
+    } catch (err) {
+      console.error(`  Error processing ${year}: ${err.message}`);
+    }
+    console.log();
+  }
+
+  console.log("Done. Run `npm run build` to rebuild the site.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/enrich-wrapped-images.mjs
+++ b/scripts/enrich-wrapped-images.mjs
@@ -110,32 +110,42 @@ function pickImage(images) {
   return images.find((img) => img.width === 640)?.url || images[0]?.url || "";
 }
 
+const MAX_RETRIES = 3;
+
 async function spotifyGet(url, accessToken) {
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
 
-  if (res.status === 429) {
-    const retryAfter = parseInt(res.headers.get("Retry-After") ?? "30", 10);
-    if (retryAfter > 300) {
-      // Daily quota exhausted — not worth waiting. Throw so the caller records
-      // an empty result and we move on rather than blocking for hours.
-      throw new Error(
-        `Spotify API error (429): daily quota exhausted (Retry-After: ${retryAfter}s). ` +
-          `Re-run this script tomorrow to fill in remaining images.`
-      );
+    if (res.status === 429) {
+      const retryAfter = parseInt(res.headers.get("Retry-After") ?? "30", 10);
+      if (retryAfter > 300) {
+        // Daily quota exhausted — not worth waiting. Throw so the caller records
+        // an empty result and we move on rather than blocking for hours.
+        throw new Error(
+          `Spotify API error (429): daily quota exhausted (Retry-After: ${retryAfter}s). ` +
+            `Re-run this script tomorrow to fill in remaining images.`
+        );
+      }
+      if (attempt === MAX_RETRIES) {
+        throw new Error(
+          `Spotify API error (429): rate limited after ${MAX_RETRIES} attempts. ` +
+            `Re-run this script to resume.`
+        );
+      }
+      // Short-term rate limit — wait and retry.
+      console.log(`\n  Rate limited — waiting ${retryAfter}s before retry (attempt ${attempt}/${MAX_RETRIES})...`);
+      await new Promise((r) => setTimeout(r, retryAfter * 1000));
+      continue;
     }
-    // Short-term rate limit — wait and retry once.
-    console.log(`\n  Rate limited — waiting ${retryAfter}s before retry...`);
-    await new Promise((r) => setTimeout(r, retryAfter * 1000));
-    return spotifyGet(url, accessToken);
-  }
 
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`Spotify API error (${res.status}): ${text}`);
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Spotify API error (${res.status}): ${text}`);
+    }
+    return res.json();
   }
-  return res.json();
 }
 
 /** Search for an artist by exact name, return the best-match image URL. */

--- a/src/data/wrapped/2018.json
+++ b/src/data/wrapped/2018.json
@@ -1484,5 +1484,411 @@
       "artist": "Sticky Fingers",
       "duration": "0:30"
     }
+  },
+  "apiSnapshot": {
+    "topArtists": [
+      {
+        "name": "Red Hot Chili Peppers",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc33cc15260b767ddec982ce8",
+        "url": "https://open.spotify.com/artist/0L8ExT028jH3ddEcZwqJJ5"
+      },
+      {
+        "name": "Oliver Schories",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb2c3d308cf912a78c96fd41f3",
+        "url": "https://open.spotify.com/artist/0iTjLBepeGaLgZS18kxgRq"
+      },
+      {
+        "name": "Sam Lachow",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebb44e0d4e7879678f8e7bde3f",
+        "url": "https://open.spotify.com/artist/42UrF25gDVhovYn4Dd422d"
+      },
+      {
+        "name": "Jack Johnson",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0bf3ff1eaa4c0d6d664ccc3f",
+        "url": "https://open.spotify.com/artist/3GBPw9NK25X1Wt2OUvOwY3"
+      },
+      {
+        "name": "Eminem",
+        "image": "https://i.scdn.co/image/ab6761610000e5eba00b11c129b27a88fc72f36b",
+        "url": "https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR"
+      },
+      {
+        "name": "Mac Miller",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebed3b89aa602145fde71a163a",
+        "url": "https://open.spotify.com/artist/4LLpKhyESsyAXpc4laK94U"
+      },
+      {
+        "name": "DOPE LEMON",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb08d96270687870e07c667bdd",
+        "url": "https://open.spotify.com/artist/7oZLKL1GjYiaAgssXsLmW8"
+      },
+      {
+        "name": "Milky Chance",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb23eb1af2ef13c5db234ff824",
+        "url": "https://open.spotify.com/artist/1hzfo8twXdOegF3xireCYs"
+      },
+      {
+        "name": "Yo Grapes",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb1b169b9d3e49af512b6d590c",
+        "url": "https://open.spotify.com/artist/7rwiN8Fkuy6Pa9lGiIGyBY"
+      },
+      {
+        "name": "Glass Animals",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebeb2cc96b0ed023c5e3675b6f",
+        "url": "https://open.spotify.com/artist/4yvcSjfu4PC0CYQyLy4wSq"
+      },
+      {
+        "name": "The Jungle Giants",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0917fdf7d54dd23b78f97a29",
+        "url": "https://open.spotify.com/artist/6wFwvxJkurQPU2UdeD4qVt"
+      },
+      {
+        "name": "Angus & Julia Stone",
+        "image": "https://i.scdn.co/image/ab6761610000e5eba6bec94f269e61676f2fe977",
+        "url": "https://open.spotify.com/artist/4tvKz56Tr39bkhcQUTO0Xr"
+      },
+      {
+        "name": "Queen",
+        "image": "https://i.scdn.co/image/ab6772690000dd2247488c35a509d42072c23976",
+        "url": "https://open.spotify.com/artist/1dfeR4HaWDbWqFHLkxsg1d"
+      },
+      {
+        "name": "Gizmo Varillas",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0a0b7b66a348655e065452ea",
+        "url": "https://open.spotify.com/artist/47i4lPow1dIRwOb85AB6lj"
+      },
+      {
+        "name": "Rodríguez",
+        "image": "https://i.scdn.co/image/d1d0f4b212e16eb6bf079e8e7bae11828378a2bc",
+        "url": "https://open.spotify.com/artist/5PrHzxc3kFm4hIrGNmelpX"
+      },
+      {
+        "name": "Kishi Bashi",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc016b2ad359f97b3ad3ae071",
+        "url": "https://open.spotify.com/artist/3LVPGE5jPPwtbGslx07YR0"
+      },
+      {
+        "name": "Boris Brejcha",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb2cc3d29c6605e96958abf585",
+        "url": "https://open.spotify.com/artist/6caPJFLv1wesmM7gwK1ACy"
+      },
+      {
+        "name": "HVOB",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb4432398038a3f585dd92165b",
+        "url": "https://open.spotify.com/artist/6RAx8RRxoHeJIqD2d0EjOa"
+      },
+      {
+        "name": "Alec Troniq",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb86dcf3da0702be1b23f1b04a",
+        "url": "https://open.spotify.com/artist/7gY2UGpmfLNKfezQPuG7Hx"
+      },
+      {
+        "name": "Eagles",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0767e116a2307495e37cd7fb",
+        "url": "https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL"
+      }
+    ],
+    "topTracks": [
+      {
+        "name": "She Goes",
+        "artist": "Oliver Schories",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a886948c7a21b6c1fa76d15f",
+        "url": "https://open.spotify.com/track/4SrRMDj3jO1yBk9pmjZHPB"
+      },
+      {
+        "name": "Gooey - Gilligan Moss Remix",
+        "artist": "Glass Animals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273715d9919fc4188d977954795",
+        "url": "https://open.spotify.com/track/1yshfaUkaAletecfWFVgtS"
+      },
+      {
+        "name": "Chateau",
+        "artist": "Angus & Julia Stone",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b38dd1336f399bbdbdcf4269",
+        "url": "https://open.spotify.com/track/1tQtURCQmQnY5ZxJNTgXKR"
+      },
+      {
+        "name": "Seasick Dream",
+        "artist": "Jack Johnson",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d7e40baf75ddce4864c5bc75",
+        "url": "https://open.spotify.com/track/1vL5bZNsFWVYED96IgWEIM"
+      },
+      {
+        "name": "Snow (Hey Oh)",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/2aibwv5hGXSgw7Yru8IYTO"
+      },
+      {
+        "name": "It All Began With a Burst",
+        "artist": "Kishi Bashi",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c3f7f5abcc43a90cb884fff0",
+        "url": "https://open.spotify.com/track/6lDH1WqbEhOtma7ETHnOaJ"
+      },
+      {
+        "name": "Mountain To Move",
+        "artist": "Nick Mulvey",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2734c8a124d8bce6a157523a8d0",
+        "url": "https://open.spotify.com/track/7zGyIkunvMO11FByE93lzZ"
+      },
+      {
+        "name": "Birthday Card",
+        "artist": "Marcus Marr",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27359afb3151616a570d357911d",
+        "url": "https://open.spotify.com/track/3Prt3S5X7nsEKv2VARtKrv"
+      },
+      {
+        "name": "I Am the Antichrist to You",
+        "artist": "Kishi Bashi",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c3f7f5abcc43a90cb884fff0",
+        "url": "https://open.spotify.com/track/3tnfHy341CDlAtcSmUtuOG"
+      },
+      {
+        "name": "Neighbors",
+        "artist": "J. Cole",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f4ca75192df162f78a24023e",
+        "url": "https://open.spotify.com/track/0utlOiJy2weVl9WTkcEWHy"
+      },
+      {
+        "name": "Yellow Mellow",
+        "artist": "Ocean Alley",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27339aae9fd82532542b19c8e60",
+        "url": "https://open.spotify.com/track/6ehgCYEjaYWAYRBVAUEILF"
+      },
+      {
+        "name": "Good Morning Children",
+        "artist": "Alec Troniq",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738a60f6792262bd4c21c6e248",
+        "url": "https://open.spotify.com/track/7b6gAh0OyzcKsg2i7Tte6u"
+      },
+      {
+        "name": "Tongues",
+        "artist": "Joywave",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f3a8d3033666a6bbafdfa845",
+        "url": "https://open.spotify.com/track/5mCprFWOqe0jB96v9RhLBo"
+      },
+      {
+        "name": "Breezeblocks",
+        "artist": "alt-J",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731e1ca90cd8fdbb0ac890a926",
+        "url": "https://open.spotify.com/track/1ZLroqJA8qoS5QEeCo0fA7"
+      },
+      {
+        "name": "Fingerprint",
+        "artist": "Lane 8",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e96a7cf14f2d32c679d86e02",
+        "url": "https://open.spotify.com/track/1Hy3CoHThqF0NBSmkmeR21"
+      },
+      {
+        "name": "Give a Little Love",
+        "artist": "Gizmo Varillas",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b363433d9507c5740d35fcb4",
+        "url": "https://open.spotify.com/track/0CQ6cbXPUsB9NcJZ2Abuc4"
+      },
+      {
+        "name": "No Ceiling",
+        "artist": "Trenton and Free Radical",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/442HYek8Qwtfg2AoSPr49j"
+      },
+      {
+        "name": "Show Me The Way",
+        "artist": "Peter Frampton",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2732aadbe54b2c387d44f49834d",
+        "url": "https://open.spotify.com/track/6BD1X1PeV5UzYUdiVaD2yL"
+      },
+      {
+        "name": "Walking On A Dream",
+        "artist": "Empire Of The Sun",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273147fd9fbc3cfd8dd10002f41",
+        "url": "https://open.spotify.com/track/3xVaJfd27n4S6ZZoyGYX4H"
+      },
+      {
+        "name": "Dark Planet",
+        "artist": "Boris Brejcha",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273831540b40428891208984f17",
+        "url": "https://open.spotify.com/track/6ZyEZpsnv8mwiMEeNRK2oq"
+      },
+      {
+        "name": "This Shit",
+        "artist": "Sol",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d0909806e2ed14b1acef7091",
+        "url": "https://open.spotify.com/track/38lFbx8dsIPvPfF8CTCW8S"
+      },
+      {
+        "name": "Lost Memory",
+        "artist": "Boris Brejcha",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2734e2f6a473a082124b6c63aab",
+        "url": "https://open.spotify.com/track/76lT30VRv09h5MQp5snmsb"
+      },
+      {
+        "name": "Marinade",
+        "artist": "DOPE LEMON",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2736e5f26c11f97c7211fe5f4fb",
+        "url": "https://open.spotify.com/track/2OFUamird9l49tMtwf8w3l"
+      },
+      {
+        "name": "Weekend (feat. Miguel)",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ee0f38410382a255e4fb15f4",
+        "url": "https://open.spotify.com/track/6GnhWMhgJb7uyiiPEiEkDA"
+      },
+      {
+        "name": "Let's Fall in Love Some More",
+        "artist": "Al Bairre",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e82b4a558e17237190799c69",
+        "url": "https://open.spotify.com/track/1SZN00cfG8T8UxDmJeqjuv"
+      },
+      {
+        "name": "All Of Me",
+        "artist": "Tanlines",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ed3640eef342c08b5fadf4a9",
+        "url": "https://open.spotify.com/track/20cFacW3LrKR2uBesEnW0q"
+      },
+      {
+        "name": "House of the Rising Sun",
+        "artist": "The Animals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27399c35f23f4edae24d409d271",
+        "url": "https://open.spotify.com/track/1D8MLfoyeJr3W7sEYsDoyv"
+      },
+      {
+        "name": "The Less I Know The Better",
+        "artist": "Tame Impala",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739e1cfc756886ac782e363d79",
+        "url": "https://open.spotify.com/track/6K4t31amVTZDgR3sKmwUJJ"
+      },
+      {
+        "name": "ELEMENT.",
+        "artist": "Kendrick Lamar",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738b52c6b9bc4e43d873869699",
+        "url": "https://open.spotify.com/track/1EaKU4dMbesXXd3BrLCtYG"
+      },
+      {
+        "name": "Used to Be in Love",
+        "artist": "The Jungle Giants",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c3cae3816afacc9ab24a7d0c",
+        "url": "https://open.spotify.com/track/2p9p2WMCH2ctlt5mUjbykS"
+      },
+      {
+        "name": "Can't Stop",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fdbcee40748537ff80a7af70",
+        "url": "https://open.spotify.com/track/4BcS4LomxUnQpzx4hCaJTs"
+      },
+      {
+        "name": "Bohemian Rhapsody - Remastered 2011",
+        "artist": "Queen",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273bb19d0c22d5709c9d73c8263",
+        "url": "https://open.spotify.com/track/2OBofMJx94NryV2SK8p8Zf"
+      },
+      {
+        "name": "Young Folks",
+        "artist": "Peter Bjorn and John",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739cf4ac84b224a02f34d2e4f6",
+        "url": "https://open.spotify.com/track/4dyx5SzxPPaD8xQIid5Wjj"
+      },
+      {
+        "name": "These Days",
+        "artist": "mike.",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d924029ec452abb98e7a5612",
+        "url": "https://open.spotify.com/track/5tsI3xxDHDgzHhn30LTQNz"
+      },
+      {
+        "name": "Wrong Man (feat. Ariana Deboo & Dave B)",
+        "artist": "Sam Lachow",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2iCsHWWYzSCJ6Z0MyeOv6h"
+      },
+      {
+        "name": "Quiet Ferocity",
+        "artist": "The Jungle Giants",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c3cae3816afacc9ab24a7d0c",
+        "url": "https://open.spotify.com/track/6Aasa0nfyOdL5DkWbWd0Z4"
+      },
+      {
+        "name": "Lucky You (feat. Joyner Lucas)",
+        "artist": "Eminem",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e4073def0c03a91e3fceaf73",
+        "url": "https://open.spotify.com/track/60SdxE8apGAxMiRrpbmLY0"
+      },
+      {
+        "name": "100 Miles and Running (ft. Wale & John Lindahl)",
+        "artist": "Logic",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27390228ca3b95c6e42a6e649b3",
+        "url": "https://open.spotify.com/track/4CstQ0SUkl0YkoeZkIZlIx"
+      },
+      {
+        "name": "Come Together - Remastered 2009",
+        "artist": "The Beatles",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273dc30583ba717007b00cceb25",
+        "url": "https://open.spotify.com/track/2EqlS6tkEnglzr7tkKAAYD"
+      },
+      {
+        "name": "All Right Now",
+        "artist": "Free",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273753c41c7fdc5e78ba017bbf5",
+        "url": "https://open.spotify.com/track/1gcESexgftSuLuML57Y69q"
+      },
+      {
+        "name": "Come As You Are",
+        "artist": "Nirvana",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fbc71c99f9c1296c56dd51b6",
+        "url": "https://open.spotify.com/track/2RsAajgo0g7bMCHxwH3Sk0"
+      },
+      {
+        "name": "Radar Love",
+        "artist": "Golden Earring",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27393b0b0bc9bc1566e23999d88",
+        "url": "https://open.spotify.com/track/4Zau4QvgyxWiWQ5KQrwL43"
+      },
+      {
+        "name": "Waiting On the World to Change",
+        "artist": "John Mayer",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fa8e8cc9d6d0862b7033dbaa",
+        "url": "https://open.spotify.com/track/1lRmQ9D6oNYiuCXdGlKCs0"
+      },
+      {
+        "name": "Stop It",
+        "artist": "FISHER",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c6b6244ab810f6b0b8528bfa",
+        "url": "https://open.spotify.com/track/627JZ3dVd88Xc5IoHOeNT5"
+      },
+      {
+        "name": "Freedom For a Change",
+        "artist": "Gizmo Varillas",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b363433d9507c5740d35fcb4",
+        "url": "https://open.spotify.com/track/6IED3V6GMa9SyP8xwkeqpD"
+      },
+      {
+        "name": "Born To Be Wild",
+        "artist": "Steppenwolf",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2732236b35e0228c0298bfbbad7",
+        "url": "https://open.spotify.com/track/39vX5jwuZ1ye6YDIGNfXog"
+      },
+      {
+        "name": "Black Betty",
+        "artist": "Ram Jam",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2732dae35818253ccb1cd0cd87d",
+        "url": "https://open.spotify.com/track/6kooDsorCpWVMGc994XjWN"
+      },
+      {
+        "name": "Tiny Dancer",
+        "artist": "Elton John",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d03ab2da904d8251a87bbc31",
+        "url": "https://open.spotify.com/track/2TVxnKdb3tqe1nhQWwwZCO"
+      },
+      {
+        "name": "Sunset Lover",
+        "artist": "Petit Biscuit",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273014080d39d56c94c0b285362",
+        "url": "https://open.spotify.com/track/0hNduWmlWmEmuwEFcYvRu1"
+      },
+      {
+        "name": "Africa",
+        "artist": "TOTO",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ebd6d20c0082524244ef83df",
+        "url": "https://open.spotify.com/track/2374M0fQpWi3dLnB54qaLX"
+      }
+    ]
   }
 }

--- a/src/data/wrapped/2019.json
+++ b/src/data/wrapped/2019.json
@@ -1661,5 +1661,411 @@
     "returningCount": 15,
     "newCount": 5,
     "returningPct": 75
+  },
+  "apiSnapshot": {
+    "topArtists": [
+      {
+        "name": "Red Hot Chili Peppers",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc33cc15260b767ddec982ce8",
+        "url": "https://open.spotify.com/artist/0L8ExT028jH3ddEcZwqJJ5"
+      },
+      {
+        "name": "Jack Johnson",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0bf3ff1eaa4c0d6d664ccc3f",
+        "url": "https://open.spotify.com/artist/3GBPw9NK25X1Wt2OUvOwY3"
+      },
+      {
+        "name": "Milky Chance",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb23eb1af2ef13c5db234ff824",
+        "url": "https://open.spotify.com/artist/1hzfo8twXdOegF3xireCYs"
+      },
+      {
+        "name": "Eminem",
+        "image": "https://i.scdn.co/image/ab6761610000e5eba00b11c129b27a88fc72f36b",
+        "url": "https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR"
+      },
+      {
+        "name": "Queen",
+        "image": "https://i.scdn.co/image/ab6772690000dd2247488c35a509d42072c23976",
+        "url": "https://open.spotify.com/artist/1dfeR4HaWDbWqFHLkxsg1d"
+      },
+      {
+        "name": "DOPE LEMON",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb08d96270687870e07c667bdd",
+        "url": "https://open.spotify.com/artist/7oZLKL1GjYiaAgssXsLmW8"
+      },
+      {
+        "name": "Bob Marley & The Wailers",
+        "image": "https://i.scdn.co/image/4cd57e5e12ea2c24644c40886d65a9b22eca9802",
+        "url": "https://open.spotify.com/artist/2QsynagSdAqZj3U9HgDzjD"
+      },
+      {
+        "name": "The Jungle Giants",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0917fdf7d54dd23b78f97a29",
+        "url": "https://open.spotify.com/artist/6wFwvxJkurQPU2UdeD4qVt"
+      },
+      {
+        "name": "Led Zeppelin",
+        "image": "https://i.scdn.co/image/207803ce008388d3427a685254f9de6a8f61dc2e",
+        "url": "https://open.spotify.com/artist/36QJpDe2go2KgaRleHCDTp"
+      },
+      {
+        "name": "Sam Lachow",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebb44e0d4e7879678f8e7bde3f",
+        "url": "https://open.spotify.com/artist/42UrF25gDVhovYn4Dd422d"
+      },
+      {
+        "name": "Kendrick Lamar",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb39ba6dcd4355c03de0b50918",
+        "url": "https://open.spotify.com/artist/2YZyLoL8N0Wb9xBt1NhZWg"
+      },
+      {
+        "name": "Eagles",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0767e116a2307495e37cd7fb",
+        "url": "https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL"
+      },
+      {
+        "name": "Yo Grapes",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb1b169b9d3e49af512b6d590c",
+        "url": "https://open.spotify.com/artist/7rwiN8Fkuy6Pa9lGiIGyBY"
+      },
+      {
+        "name": "Ocean Alley",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb92b004bf56ed88782f46e4a8",
+        "url": "https://open.spotify.com/artist/18lpwfiys4GtdHWNUu9qQr"
+      },
+      {
+        "name": "AC/DC",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc4c77549095c86acb4e77b37",
+        "url": "https://open.spotify.com/artist/711MCceyCBcFnzjGY4Q7Un"
+      },
+      {
+        "name": "Kollektiv Turmstrasse",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebb34f25f5e9b8a9adcc1fc8db",
+        "url": "https://open.spotify.com/artist/1oXiuCd5F0DcnmXH5KaM6N"
+      },
+      {
+        "name": "Drake",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb4293385d324db8558179afd9",
+        "url": "https://open.spotify.com/artist/3TVXtAsR1Inumwj472S9r4"
+      },
+      {
+        "name": "Rodríguez",
+        "image": "https://i.scdn.co/image/d1d0f4b212e16eb6bf079e8e7bae11828378a2bc",
+        "url": "https://open.spotify.com/artist/5PrHzxc3kFm4hIrGNmelpX"
+      },
+      {
+        "name": "Mac Miller",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebed3b89aa602145fde71a163a",
+        "url": "https://open.spotify.com/artist/4LLpKhyESsyAXpc4laK94U"
+      },
+      {
+        "name": "Sticky Fingers",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb21ebb7e4085f6c9765fbe9a5",
+        "url": "https://open.spotify.com/artist/3ZGr7nQBXDU2WhyXgRVbt0"
+      }
+    ],
+    "topTracks": [
+      {
+        "name": "Gooey - Gilligan Moss Remix",
+        "artist": "Glass Animals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273715d9919fc4188d977954795",
+        "url": "https://open.spotify.com/track/1yshfaUkaAletecfWFVgtS"
+      },
+      {
+        "name": "Snow (Hey Oh)",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/2aibwv5hGXSgw7Yru8IYTO"
+      },
+      {
+        "name": "Birthday Card",
+        "artist": "Marcus Marr",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27359afb3151616a570d357911d",
+        "url": "https://open.spotify.com/track/3Prt3S5X7nsEKv2VARtKrv"
+      },
+      {
+        "name": "Till The Sun Comes Up",
+        "artist": "Jack and the Weatherman",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273bf751e34c63a1ef11d0423cc",
+        "url": "https://open.spotify.com/track/7IxJ4XaMCSJ0JKBffm54z3"
+      },
+      {
+        "name": "Lay It on Me",
+        "artist": "Vance Joy",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739ac709b94022896013465886",
+        "url": "https://open.spotify.com/track/7oekneJCJO74ycdLzdk16v"
+      },
+      {
+        "name": "Chateau",
+        "artist": "Angus & Julia Stone",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b38dd1336f399bbdbdcf4269",
+        "url": "https://open.spotify.com/track/1tQtURCQmQnY5ZxJNTgXKR"
+      },
+      {
+        "name": "Crazy Train",
+        "artist": "Ozzy Osbourne",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2734936b5b7caeb7524e50fd8cb",
+        "url": "https://open.spotify.com/track/7ACxUo21jtTHzy7ZEV56vU"
+      },
+      {
+        "name": "Mathematics",
+        "artist": "Mos Def",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27389b56f56323925d57b38944d",
+        "url": "https://open.spotify.com/track/3gRlmtdCyNoKiyozn2pqc9"
+      },
+      {
+        "name": "Planet Caravan",
+        "artist": "Black Sabbath",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273605b25c031f809d78054a13c",
+        "url": "https://open.spotify.com/track/4zgHtuasZkiZu1caZwxF5P"
+      },
+      {
+        "name": "I Follow Rivers - The Magician Remix",
+        "artist": "Lykke Li",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b99d8c4872c3452e77dc43e0",
+        "url": "https://open.spotify.com/track/008WBHFU6GcIwclrVfKBg8"
+      },
+      {
+        "name": "The Forgotten People",
+        "artist": "BehrEllips",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27376d45716e7d73a436a52366a",
+        "url": "https://open.spotify.com/track/0fpKHYhMTq4bSZQ5aukuAl"
+      },
+      {
+        "name": "Baby I'm Yours",
+        "artist": "Breakbot",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d55f44fb47f63f0e7048a5a1",
+        "url": "https://open.spotify.com/track/5jr6pG3khBcBXZRm8NogSe"
+      },
+      {
+        "name": "Kickstart My Heart",
+        "artist": "Mötley Crüe",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fc30908354ee3be55dc6feb2",
+        "url": "https://open.spotify.com/track/4Yqy0GpeDEXLibWJCZyQew"
+      },
+      {
+        "name": "White Tiger - Single Version",
+        "artist": "Izzy Bizu",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273364d7c8e19c9c269797b7afe",
+        "url": "https://open.spotify.com/track/64I0PKLFEKlcvc7fEVUGq0"
+      },
+      {
+        "name": "All I Do (feat. Bryan Chambers) - Cleptomaniacs Mix",
+        "artist": "Cleptomaniacs",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7bfJEH931lVZg8JgOJrOsU"
+      },
+      {
+        "name": "Fortunate Son",
+        "artist": "Creedence Clearwater Revival",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e88774c6adcd5b8cce420d0c",
+        "url": "https://open.spotify.com/track/5DSfAqZ5YjOMf4C0Elvpa0"
+      },
+      {
+        "name": "Sorry I Am Late - Extended",
+        "artist": "Kollektiv Turmstrasse",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27362af0accb17ffdba0cd5cad1",
+        "url": "https://open.spotify.com/track/4FpawvuBz4HxTz7UqR4ter"
+      },
+      {
+        "name": "Let's Fall in Love Some More",
+        "artist": "Al Bairre",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e82b4a558e17237190799c69",
+        "url": "https://open.spotify.com/track/1SZN00cfG8T8UxDmJeqjuv"
+      },
+      {
+        "name": "Seasick Dream",
+        "artist": "Jack Johnson",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d7e40baf75ddce4864c5bc75",
+        "url": "https://open.spotify.com/track/1vL5bZNsFWVYED96IgWEIM"
+      },
+      {
+        "name": "Neighbors",
+        "artist": "J. Cole",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f4ca75192df162f78a24023e",
+        "url": "https://open.spotify.com/track/0utlOiJy2weVl9WTkcEWHy"
+      },
+      {
+        "name": "Hanging Upside Down",
+        "artist": "Lime Cordiale",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27311e7855fbfb95ee635809c77",
+        "url": "https://open.spotify.com/track/37Kj037Is4AcOvj3vwzN7Z"
+      },
+      {
+        "name": "You Little Beauty",
+        "artist": "FISHER",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c9103bcebb6bf4ca93c7ad3d",
+        "url": "https://open.spotify.com/track/1gRQxbfL4ULWyTosgXSbWT"
+      },
+      {
+        "name": "Paranoid",
+        "artist": "Black Sabbath",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273174f71bdda81ecb2eddba01b",
+        "url": "https://open.spotify.com/track/3hwuHzRicnu6Ji9i1JLzor"
+      },
+      {
+        "name": "Time to Waste",
+        "artist": "Landon McNamara",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c72986bb8ac7c1c90164f21d",
+        "url": "https://open.spotify.com/track/6UOfNU34j3nj84DlFzrayQ"
+      },
+      {
+        "name": "True",
+        "artist": "Monte",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27318ceb45195da3b84f5ee4290",
+        "url": "https://open.spotify.com/track/1O5rnOLvS9VBerAE5LS0YP"
+      },
+      {
+        "name": "Dazed and Confused - 1990 Remaster",
+        "artist": "Led Zeppelin",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2736f2f499c1df1f210c9b34b32",
+        "url": "https://open.spotify.com/track/6hu1f1cXSw7OAqhpSQ2zDy"
+      },
+      {
+        "name": "Hold On",
+        "artist": "SBTRKT",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273779c4164a3cb1e610a757c41",
+        "url": "https://open.spotify.com/track/47GsUibP7RiUL7SQ7YFfhu"
+      },
+      {
+        "name": "Smells Like Teen Spirit",
+        "artist": "Nirvana",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fbc71c99f9c1296c56dd51b6",
+        "url": "https://open.spotify.com/track/4CeeEOM32jQcH3eN9Q2dGj"
+      },
+      {
+        "name": "Give a Little Love",
+        "artist": "Gizmo Varillas",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b363433d9507c5740d35fcb4",
+        "url": "https://open.spotify.com/track/0CQ6cbXPUsB9NcJZ2Abuc4"
+      },
+      {
+        "name": "See I Wrote it for You",
+        "artist": "Jeremy Loops",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f42f1310fd60b9208c69c468",
+        "url": "https://open.spotify.com/track/4KjMGxzI2FEanQfFcso8N0"
+      },
+      {
+        "name": "Africans Want To Be Free - Original",
+        "artist": "Tjard",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739efad08c33910f9abc5f176d",
+        "url": "https://open.spotify.com/track/3V0Lisqkieeltn5okyK48P"
+      },
+      {
+        "name": "Communicate (feat. Ravyn Lenae)",
+        "artist": "Mick Jenkins",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0udCQ78g2s33TELmtndMqd"
+      },
+      {
+        "name": "Come As You Are",
+        "artist": "Nirvana",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fbc71c99f9c1296c56dd51b6",
+        "url": "https://open.spotify.com/track/2RsAajgo0g7bMCHxwH3Sk0"
+      },
+      {
+        "name": "Palm Tree Memories - n'to Remix",
+        "artist": "Oliver Schories",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731af726fc7432276d31c4973b",
+        "url": "https://open.spotify.com/track/58RfdddQzwXPncXQotOHY4"
+      },
+      {
+        "name": "Under the Bridge",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2735590b4ee88187cb06a5b102d",
+        "url": "https://open.spotify.com/track/23NPGXlSaIqWzvxIRhM2oG"
+      },
+      {
+        "name": "On Your Way Down",
+        "artist": "The Jungle Giants",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c3cae3816afacc9ab24a7d0c",
+        "url": "https://open.spotify.com/track/1vIkfCStqvLcMlp41M8zjQ"
+      },
+      {
+        "name": "Whole Lotta Love - 1990 Remaster",
+        "artist": "Led Zeppelin",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fc4f17340773c6c3579fea0d",
+        "url": "https://open.spotify.com/track/0hCB0YR03f6AmQaHbwWDe8"
+      },
+      {
+        "name": "Walking On A Dream",
+        "artist": "Empire Of The Sun",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273147fd9fbc3cfd8dd10002f41",
+        "url": "https://open.spotify.com/track/3xVaJfd27n4S6ZZoyGYX4H"
+      },
+      {
+        "name": "Back To Back",
+        "artist": "Drake",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2733dc98872a3cf00117e4623e5",
+        "url": "https://open.spotify.com/track/5lFDtgWsjRJu8fPOAyJIAK"
+      },
+      {
+        "name": "Yellow Mellow",
+        "artist": "Ocean Alley",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27339aae9fd82532542b19c8e60",
+        "url": "https://open.spotify.com/track/6ehgCYEjaYWAYRBVAUEILF"
+      },
+      {
+        "name": "The Less I Know The Better",
+        "artist": "Tame Impala",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739e1cfc756886ac782e363d79",
+        "url": "https://open.spotify.com/track/6K4t31amVTZDgR3sKmwUJJ"
+      },
+      {
+        "name": "Conjure Dreams",
+        "artist": "Maceo Plex",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273efe7013af88dd56482132a57",
+        "url": "https://open.spotify.com/track/3B82rCeX1aIZGC19Hf85fh"
+      },
+      {
+        "name": "Scar Tissue",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a9249ebb15ca7a5b75f16a90",
+        "url": "https://open.spotify.com/track/2QOMGq8wVTZbLmh7McrvgF"
+      },
+      {
+        "name": "You & I",
+        "artist": "Crystal Fighters",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e8f761cc5305b478ab80cfea",
+        "url": "https://open.spotify.com/track/1GygPCIcsfPWPECL78EjRG"
+      },
+      {
+        "name": "Kick, Push",
+        "artist": "Lupe Fiasco",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a81ec0503c55850ad4687940",
+        "url": "https://open.spotify.com/track/6nz35DNIzbtj5ztpDEcW1j"
+      },
+      {
+        "name": "Stairway to Heaven - Remaster",
+        "artist": "Led Zeppelin",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c8a11e48c91a982d086afc69",
+        "url": "https://open.spotify.com/track/5CQ30WqJwcep0pYcV4AMNc"
+      },
+      {
+        "name": "You Got to Love Me",
+        "artist": "DAVID AUGUST",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6fvZJ1e7tuBRmwnZDEzGdw"
+      },
+      {
+        "name": "Hold My Girl",
+        "artist": "George Ezra",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2734dc97826ec57146f19c8e228",
+        "url": "https://open.spotify.com/track/42bbDWZ8WmXTH7PkYAlGLu"
+      },
+      {
+        "name": "My Love (feat. Jess Glynne)",
+        "artist": "Route 94",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b905ed1edb5a88c573c023b0",
+        "url": "https://open.spotify.com/track/4jpbDGZz6euo0xDcLlJUDZ"
+      },
+      {
+        "name": "Africa",
+        "artist": "TOTO",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ebd6d20c0082524244ef83df",
+        "url": "https://open.spotify.com/track/2374M0fQpWi3dLnB54qaLX"
+      }
+    ]
   }
 }

--- a/src/data/wrapped/2020.json
+++ b/src/data/wrapped/2020.json
@@ -1669,5 +1669,411 @@
     "returningCount": 16,
     "newCount": 4,
     "returningPct": 80
+  },
+  "apiSnapshot": {
+    "topArtists": [
+      {
+        "name": "Red Hot Chili Peppers",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc33cc15260b767ddec982ce8",
+        "url": "https://open.spotify.com/artist/0L8ExT028jH3ddEcZwqJJ5"
+      },
+      {
+        "name": "Mac Miller",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebed3b89aa602145fde71a163a",
+        "url": "https://open.spotify.com/artist/4LLpKhyESsyAXpc4laK94U"
+      },
+      {
+        "name": "Jack Johnson",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0bf3ff1eaa4c0d6d664ccc3f",
+        "url": "https://open.spotify.com/artist/3GBPw9NK25X1Wt2OUvOwY3"
+      },
+      {
+        "name": "Milky Chance",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb23eb1af2ef13c5db234ff824",
+        "url": "https://open.spotify.com/artist/1hzfo8twXdOegF3xireCYs"
+      },
+      {
+        "name": "Bob Marley & The Wailers",
+        "image": "https://i.scdn.co/image/4cd57e5e12ea2c24644c40886d65a9b22eca9802",
+        "url": "https://open.spotify.com/artist/2QsynagSdAqZj3U9HgDzjD"
+      },
+      {
+        "name": "Skegss",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb41154a8547723f1170893b47",
+        "url": "https://open.spotify.com/artist/3SGLeWc7J5Ve0CinAOrb3a"
+      },
+      {
+        "name": "Twenty One Pilots",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb61a7ea26d33ded218cd1e59d",
+        "url": "https://open.spotify.com/artist/3YQKmKGau1PzlVlkL1iodx"
+      },
+      {
+        "name": "Etta James",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb058531dfd9746a96ad85265f",
+        "url": "https://open.spotify.com/artist/0iOVhN3tnSvgDbcg25JoJb"
+      },
+      {
+        "name": "Kendrick Lamar",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb39ba6dcd4355c03de0b50918",
+        "url": "https://open.spotify.com/artist/2YZyLoL8N0Wb9xBt1NhZWg"
+      },
+      {
+        "name": "Kanye West",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb6e835a500e791bf9c27a422a",
+        "url": "https://open.spotify.com/artist/5K4W6rqBFWDnAN6FQUkS6x"
+      },
+      {
+        "name": "Chance the Rapper",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebd4d18d62a36a26fe36b70e2a",
+        "url": "https://open.spotify.com/artist/1anyVhU62p31KFi8MEzkbf"
+      },
+      {
+        "name": "Rodríguez",
+        "image": "https://i.scdn.co/image/d1d0f4b212e16eb6bf079e8e7bae11828378a2bc",
+        "url": "https://open.spotify.com/artist/5PrHzxc3kFm4hIrGNmelpX"
+      },
+      {
+        "name": "Led Zeppelin",
+        "image": "https://i.scdn.co/image/207803ce008388d3427a685254f9de6a8f61dc2e",
+        "url": "https://open.spotify.com/artist/36QJpDe2go2KgaRleHCDTp"
+      },
+      {
+        "name": "Eminem",
+        "image": "https://i.scdn.co/image/ab6761610000e5eba00b11c129b27a88fc72f36b",
+        "url": "https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR"
+      },
+      {
+        "name": "Queen",
+        "image": "https://i.scdn.co/image/ab6772690000dd2247488c35a509d42072c23976",
+        "url": "https://open.spotify.com/artist/1dfeR4HaWDbWqFHLkxsg1d"
+      },
+      {
+        "name": "AC/DC",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc4c77549095c86acb4e77b37",
+        "url": "https://open.spotify.com/artist/711MCceyCBcFnzjGY4Q7Un"
+      },
+      {
+        "name": "Black Sabbath",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb4870cd833ebe1092601820c3",
+        "url": "https://open.spotify.com/artist/5M52tdBnJaKSvOpJGz8mfZ"
+      },
+      {
+        "name": "Desmond and the Tutus",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb01f51145b8818d9915fb588d",
+        "url": "https://open.spotify.com/artist/2Fe88RexUZSpwGxgpaR5uz"
+      },
+      {
+        "name": "Yo Grapes",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb1b169b9d3e49af512b6d590c",
+        "url": "https://open.spotify.com/artist/7rwiN8Fkuy6Pa9lGiIGyBY"
+      },
+      {
+        "name": "Sam Lachow",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebb44e0d4e7879678f8e7bde3f",
+        "url": "https://open.spotify.com/artist/42UrF25gDVhovYn4Dd422d"
+      }
+    ],
+    "topTracks": [
+      {
+        "name": "Gooey - Gilligan Moss Remix",
+        "artist": "Glass Animals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273715d9919fc4188d977954795",
+        "url": "https://open.spotify.com/track/1yshfaUkaAletecfWFVgtS"
+      },
+      {
+        "name": "Good News",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d9d8f1a08476cd347fbea313",
+        "url": "https://open.spotify.com/track/1DWZUa5Mzf2BwzpHtgbHPY"
+      },
+      {
+        "name": "Sundress",
+        "artist": "A$AP Rocky",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731ae967e4a02c7a39eb3c189b",
+        "url": "https://open.spotify.com/track/2aPTvyE09vUCRwVvj0I8WK"
+      },
+      {
+        "name": "Snow (Hey Oh)",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/2aibwv5hGXSgw7Yru8IYTO"
+      },
+      {
+        "name": "The Spins",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273bd510ebd3fc410e97e80b892",
+        "url": "https://open.spotify.com/track/3iEUDvanZwQhLCIqUmCR7N"
+      },
+      {
+        "name": "Whole Lotta Love - 1990 Remaster",
+        "artist": "Led Zeppelin",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fc4f17340773c6c3579fea0d",
+        "url": "https://open.spotify.com/track/0hCB0YR03f6AmQaHbwWDe8"
+      },
+      {
+        "name": "Good Morning Children",
+        "artist": "Alec Troniq",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738a60f6792262bd4c21c6e248",
+        "url": "https://open.spotify.com/track/7b6gAh0OyzcKsg2i7Tte6u"
+      },
+      {
+        "name": "Dark Necessities",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27358406b3f1ac3ceaff7a64fef",
+        "url": "https://open.spotify.com/track/2oaK4JLVnmRGIO9ytBE1bt"
+      },
+      {
+        "name": "My Blood",
+        "artist": "Twenty One Pilots",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d1d301e737da4324479c6660",
+        "url": "https://open.spotify.com/track/5HeKOKc4phmLn8e4I7EkzD"
+      },
+      {
+        "name": "My Number",
+        "artist": "Foals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738b04dacf186124a62bc667a7",
+        "url": "https://open.spotify.com/track/04caEZhAsQKnWqKsMwk9ud"
+      },
+      {
+        "name": "Up In The Clouds",
+        "artist": "Skegss",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27398c36965b14a067801648020",
+        "url": "https://open.spotify.com/track/440m8MPuMzg5PkipV7Sh45"
+      },
+      {
+        "name": "Smells Like Teen Spirit",
+        "artist": "Nirvana",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fbc71c99f9c1296c56dd51b6",
+        "url": "https://open.spotify.com/track/4CeeEOM32jQcH3eN9Q2dGj"
+      },
+      {
+        "name": "Let's Stare at the Sun",
+        "artist": "We Are Charlie",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b4f17544de7d7977721500d8",
+        "url": "https://open.spotify.com/track/6u8Rn5PtaxUwAG0rFaectP"
+      },
+      {
+        "name": "Nikes On My Feet",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273bd510ebd3fc410e97e80b892",
+        "url": "https://open.spotify.com/track/0m0GzwCkfuFcxOlLjgpudo"
+      },
+      {
+        "name": "The Getaway",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27358406b3f1ac3ceaff7a64fef",
+        "url": "https://open.spotify.com/track/3bIQIx7hveYPQDdhjZ1kcq"
+      },
+      {
+        "name": "Sunflower Seeds",
+        "artist": "Bryce Vine",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d398d6f25c9110cc2c5a07e7",
+        "url": "https://open.spotify.com/track/4MJfCOcc2PpWOrUqOpvy1S"
+      },
+      {
+        "name": "Electric Feel",
+        "artist": "MGMT",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738b32b139981e79f2ebe005eb",
+        "url": "https://open.spotify.com/track/3FtYbEfBqAlGO46NUDQSAt"
+      },
+      {
+        "name": "Hold On",
+        "artist": "SBTRKT",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273779c4164a3cb1e610a757c41",
+        "url": "https://open.spotify.com/track/47GsUibP7RiUL7SQ7YFfhu"
+      },
+      {
+        "name": "Could You Be Loved",
+        "artist": "Bob Marley & The Wailers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731c40418d1c37d727e8e91b04",
+        "url": "https://open.spotify.com/track/5O4erNlJ74PIF6kGol1ZrC"
+      },
+      {
+        "name": "Ode to You (feat. Nonku)",
+        "artist": "Jack Parow",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2732dd7eed0dfc4a1b1182b6e55",
+        "url": "https://open.spotify.com/track/5VcT69lQkH6LUJLHQpaPzJ"
+      },
+      {
+        "name": "Roll The Bones (Audiotree Live Version)",
+        "artist": "Shakey Graves",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731358ae16f50d11027cd05ccc",
+        "url": "https://open.spotify.com/track/0ahcTCz4kcic6vfIEIlFkq"
+      },
+      {
+        "name": "All My Problems",
+        "artist": "Surf Trash",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273bcd813c12dd73fe680dba3db",
+        "url": "https://open.spotify.com/track/6e7upKEilNsoiRrcPkYKOE"
+      },
+      {
+        "name": "Good Morning",
+        "artist": "Kanye West",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27326f7f19c7f0381e56156c94a",
+        "url": "https://open.spotify.com/track/6MXXY2eiWkpDCezVCc0cMH"
+      },
+      {
+        "name": "Come As You Are",
+        "artist": "Nirvana",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fbc71c99f9c1296c56dd51b6",
+        "url": "https://open.spotify.com/track/2RsAajgo0g7bMCHxwH3Sk0"
+      },
+      {
+        "name": "Crazy Train",
+        "artist": "Ozzy Osbourne",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2734936b5b7caeb7524e50fd8cb",
+        "url": "https://open.spotify.com/track/7ACxUo21jtTHzy7ZEV56vU"
+      },
+      {
+        "name": "Close These Curtains - Stimming Remix",
+        "artist": "Yoko Duo",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c55f08045aa2b4df4684b59d",
+        "url": "https://open.spotify.com/track/0ZYQ8J5CmB7EBnFCWwZfaG"
+      },
+      {
+        "name": "The Passenger",
+        "artist": "Iggy Pop",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2734aa5f679427e35409a06f225",
+        "url": "https://open.spotify.com/track/15BQ7vEDv2LJuh8TxWIhtd"
+      },
+      {
+        "name": "All Along the Watchtower",
+        "artist": "Jimi Hendrix",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273522088789d49e216d9818292",
+        "url": "https://open.spotify.com/track/2aoo2jlRnM3A0NyLQqMN2f"
+      },
+      {
+        "name": "Weekend (feat. Miguel)",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ee0f38410382a255e4fb15f4",
+        "url": "https://open.spotify.com/track/6GnhWMhgJb7uyiiPEiEkDA"
+      },
+      {
+        "name": "Kool Aid & Frozen Pizza",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273bd510ebd3fc410e97e80b892",
+        "url": "https://open.spotify.com/track/0mbTcbWh2fW7P3JPki3AI0"
+      },
+      {
+        "name": "Walking On A Dream",
+        "artist": "Empire Of The Sun",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273147fd9fbc3cfd8dd10002f41",
+        "url": "https://open.spotify.com/track/3xVaJfd27n4S6ZZoyGYX4H"
+      },
+      {
+        "name": "O Pa Mi Titi Deabe - Armonica Remix",
+        "artist": "Mowgan",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27350b9ec32a0741bba65e44369",
+        "url": "https://open.spotify.com/track/4WVPihbt1LPe28IfkGfYux"
+      },
+      {
+        "name": "Two High",
+        "artist": "Moon Taxi",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27371c76644877c5a459c86a11e",
+        "url": "https://open.spotify.com/track/5huOzlgCK7PsMSG4TFBvKY"
+      },
+      {
+        "name": "Seasick Dream",
+        "artist": "Jack Johnson",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d7e40baf75ddce4864c5bc75",
+        "url": "https://open.spotify.com/track/1vL5bZNsFWVYED96IgWEIM"
+      },
+      {
+        "name": "Still Young",
+        "artist": "The Cat Empire",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27352e95fbe14a1db2ad43e086b",
+        "url": "https://open.spotify.com/track/730GIYt57qXR0LgXuw7KPn"
+      },
+      {
+        "name": "A Dream of You and Me",
+        "artist": "Future Islands",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2730896bc513dc78701474ecc03",
+        "url": "https://open.spotify.com/track/44GeTdr7MktZDqNUkLaj5h"
+      },
+      {
+        "name": "Coming Along",
+        "artist": "Sunset Sweatshop",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738217d648749a8f971b771afb",
+        "url": "https://open.spotify.com/track/5rpmwkjhUVZvXun139ddzG"
+      },
+      {
+        "name": "Painting (Masterpiece)",
+        "artist": "Lewis Del Mar",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739b99d883df80adb90738ff81",
+        "url": "https://open.spotify.com/track/4kK14radw0XfwxJDPt9tnP"
+      },
+      {
+        "name": "Under the Bridge",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2735590b4ee88187cb06a5b102d",
+        "url": "https://open.spotify.com/track/23NPGXlSaIqWzvxIRhM2oG"
+      },
+      {
+        "name": "Chateau",
+        "artist": "Angus & Julia Stone",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b38dd1336f399bbdbdcf4269",
+        "url": "https://open.spotify.com/track/1tQtURCQmQnY5ZxJNTgXKR"
+      },
+      {
+        "name": "Off The Ground",
+        "artist": "Anderson .Paak",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2735d7d7120db1b859d5077e1d2",
+        "url": "https://open.spotify.com/track/4lMLL0QOt8dLRp5UGXjZLi"
+      },
+      {
+        "name": "Come Together - Remastered 2009",
+        "artist": "The Beatles",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273dc30583ba717007b00cceb25",
+        "url": "https://open.spotify.com/track/2EqlS6tkEnglzr7tkKAAYD"
+      },
+      {
+        "name": "Scar Tissue",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a9249ebb15ca7a5b75f16a90",
+        "url": "https://open.spotify.com/track/2QOMGq8wVTZbLmh7McrvgF"
+      },
+      {
+        "name": "Closer",
+        "artist": "Kaum",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ec0d69e67bb29249154ee839",
+        "url": "https://open.spotify.com/track/7pwEE1f6NDBnWQB9yQwuCW"
+      },
+      {
+        "name": "Ladders",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f4101b35799d5966d49025e4",
+        "url": "https://open.spotify.com/track/4HxNX0GQCkdZEDSj6MZZTu"
+      },
+      {
+        "name": "(Don't Fear) The Reaper",
+        "artist": "Blue Öyster Cult",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273aa802dc9f870e66a8bb6a2a2",
+        "url": "https://open.spotify.com/track/5QTxFnGygVM4jFQiBovmRo"
+      },
+      {
+        "name": "Flow",
+        "artist": "Crooked Colours",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a1b878265536bbaaa27cb29e",
+        "url": "https://open.spotify.com/track/7mE57yFVWevAttx4HvLZKi"
+      },
+      {
+        "name": "You & I",
+        "artist": "Crystal Fighters",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e8f761cc5305b478ab80cfea",
+        "url": "https://open.spotify.com/track/1GygPCIcsfPWPECL78EjRG"
+      },
+      {
+        "name": "Cool Around You",
+        "artist": "Yo Grapes",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b6f2138236801acb54ac5870",
+        "url": "https://open.spotify.com/track/3GIhqbypBDGF8ys1TkzbGr"
+      },
+      {
+        "name": "Go Rilla",
+        "artist": "FIL BO RIVA",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27308c6b559cd42589cc416ff99",
+        "url": "https://open.spotify.com/track/7jRQhHVvq9tnrp3HH9Sw23"
+      }
+    ]
   }
 }

--- a/src/data/wrapped/2021.json
+++ b/src/data/wrapped/2021.json
@@ -1677,5 +1677,411 @@
     "returningCount": 19,
     "newCount": 1,
     "returningPct": 95
+  },
+  "apiSnapshot": {
+    "topArtists": [
+      {
+        "name": "Red Hot Chili Peppers",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc33cc15260b767ddec982ce8",
+        "url": "https://open.spotify.com/artist/0L8ExT028jH3ddEcZwqJJ5"
+      },
+      {
+        "name": "Mac Miller",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebed3b89aa602145fde71a163a",
+        "url": "https://open.spotify.com/artist/4LLpKhyESsyAXpc4laK94U"
+      },
+      {
+        "name": "Kanye West",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb6e835a500e791bf9c27a422a",
+        "url": "https://open.spotify.com/artist/5K4W6rqBFWDnAN6FQUkS6x"
+      },
+      {
+        "name": "Twenty One Pilots",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb61a7ea26d33ded218cd1e59d",
+        "url": "https://open.spotify.com/artist/3YQKmKGau1PzlVlkL1iodx"
+      },
+      {
+        "name": "Skegss",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb41154a8547723f1170893b47",
+        "url": "https://open.spotify.com/artist/3SGLeWc7J5Ve0CinAOrb3a"
+      },
+      {
+        "name": "Milky Chance",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb23eb1af2ef13c5db234ff824",
+        "url": "https://open.spotify.com/artist/1hzfo8twXdOegF3xireCYs"
+      },
+      {
+        "name": "Black Sabbath",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb4870cd833ebe1092601820c3",
+        "url": "https://open.spotify.com/artist/5M52tdBnJaKSvOpJGz8mfZ"
+      },
+      {
+        "name": "Eminem",
+        "image": "https://i.scdn.co/image/ab6761610000e5eba00b11c129b27a88fc72f36b",
+        "url": "https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR"
+      },
+      {
+        "name": "andhim",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebd7d74c48f97de722a7871d9f",
+        "url": "https://open.spotify.com/artist/6XJeFzmI6vrWyHcdB7EImP"
+      },
+      {
+        "name": "AC/DC",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc4c77549095c86acb4e77b37",
+        "url": "https://open.spotify.com/artist/711MCceyCBcFnzjGY4Q7Un"
+      },
+      {
+        "name": "DOPE LEMON",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb08d96270687870e07c667bdd",
+        "url": "https://open.spotify.com/artist/7oZLKL1GjYiaAgssXsLmW8"
+      },
+      {
+        "name": "Jack Johnson",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0bf3ff1eaa4c0d6d664ccc3f",
+        "url": "https://open.spotify.com/artist/3GBPw9NK25X1Wt2OUvOwY3"
+      },
+      {
+        "name": "Chance the Rapper",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebd4d18d62a36a26fe36b70e2a",
+        "url": "https://open.spotify.com/artist/1anyVhU62p31KFi8MEzkbf"
+      },
+      {
+        "name": "Queen",
+        "image": "https://i.scdn.co/image/ab6772690000dd2247488c35a509d42072c23976",
+        "url": "https://open.spotify.com/artist/1dfeR4HaWDbWqFHLkxsg1d"
+      },
+      {
+        "name": "Led Zeppelin",
+        "image": "https://i.scdn.co/image/207803ce008388d3427a685254f9de6a8f61dc2e",
+        "url": "https://open.spotify.com/artist/36QJpDe2go2KgaRleHCDTp"
+      },
+      {
+        "name": "Rodríguez",
+        "image": "https://i.scdn.co/image/d1d0f4b212e16eb6bf079e8e7bae11828378a2bc",
+        "url": "https://open.spotify.com/artist/5PrHzxc3kFm4hIrGNmelpX"
+      },
+      {
+        "name": "Bob Marley & The Wailers",
+        "image": "https://i.scdn.co/image/4cd57e5e12ea2c24644c40886d65a9b22eca9802",
+        "url": "https://open.spotify.com/artist/2QsynagSdAqZj3U9HgDzjD"
+      },
+      {
+        "name": "Robbie Williams",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebec4b5ff594ae3d7c5622cf23",
+        "url": "https://open.spotify.com/artist/2HcwFjNelS49kFbfvMxQYw"
+      },
+      {
+        "name": "Kid Cudi",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb5f00bb6dd7a7008d14156630",
+        "url": "https://open.spotify.com/artist/0fA0VVWsXO9YnASrzqfmYu"
+      },
+      {
+        "name": "Kendrick Lamar",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb39ba6dcd4355c03de0b50918",
+        "url": "https://open.spotify.com/artist/2YZyLoL8N0Wb9xBt1NhZWg"
+      }
+    ],
+    "topTracks": [
+      {
+        "name": "The Spins",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273bd510ebd3fc410e97e80b892",
+        "url": "https://open.spotify.com/track/3iEUDvanZwQhLCIqUmCR7N"
+      },
+      {
+        "name": "Ni**as In Paris",
+        "artist": "JAY-Z",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27352e61456aa4995ba48d94e30",
+        "url": "https://open.spotify.com/track/1auxYwYrFRqZP7t3s7w4um"
+      },
+      {
+        "name": "Stuck In The Middle With You",
+        "artist": "Stealers Wheel",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a5ce236c22035a02cf87d4de",
+        "url": "https://open.spotify.com/track/3Vby4nGmtbDo7HDJamOWkT"
+      },
+      {
+        "name": "Good Morning",
+        "artist": "Kanye West",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27326f7f19c7f0381e56156c94a",
+        "url": "https://open.spotify.com/track/6MXXY2eiWkpDCezVCc0cMH"
+      },
+      {
+        "name": "Tough As Nails",
+        "artist": "Mindchatter",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738063dbd61cf1a5110822e3b6",
+        "url": "https://open.spotify.com/track/2BEDsNidFZnq0Rcnj6WoPO"
+      },
+      {
+        "name": "Africa",
+        "artist": "TOTO",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ebd6d20c0082524244ef83df",
+        "url": "https://open.spotify.com/track/2374M0fQpWi3dLnB54qaLX"
+      },
+      {
+        "name": "Sundress",
+        "artist": "A$AP Rocky",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731ae967e4a02c7a39eb3c189b",
+        "url": "https://open.spotify.com/track/2aPTvyE09vUCRwVvj0I8WK"
+      },
+      {
+        "name": "Tongues",
+        "artist": "Joywave",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f3a8d3033666a6bbafdfa845",
+        "url": "https://open.spotify.com/track/5mCprFWOqe0jB96v9RhLBo"
+      },
+      {
+        "name": "Covered in Chrome",
+        "artist": "Violent Soho",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27329a1fe689fac4f3535541c84",
+        "url": "https://open.spotify.com/track/79y39naVOPTUt8clHsdjBp"
+      },
+      {
+        "name": "Walking On A Dream",
+        "artist": "Empire Of The Sun",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273147fd9fbc3cfd8dd10002f41",
+        "url": "https://open.spotify.com/track/3xVaJfd27n4S6ZZoyGYX4H"
+      },
+      {
+        "name": "Electric Feel",
+        "artist": "MGMT",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738b32b139981e79f2ebe005eb",
+        "url": "https://open.spotify.com/track/3FtYbEfBqAlGO46NUDQSAt"
+      },
+      {
+        "name": "Snow (Hey Oh)",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/2aibwv5hGXSgw7Yru8IYTO"
+      },
+      {
+        "name": "Scott Green",
+        "artist": "Dune Rats",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ab1565ab117cea8d53aee35c",
+        "url": "https://open.spotify.com/track/73F6UcA1ajjLKNlYoPw7TX"
+      },
+      {
+        "name": "Under the Bridge",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2735590b4ee88187cb06a5b102d",
+        "url": "https://open.spotify.com/track/23NPGXlSaIqWzvxIRhM2oG"
+      },
+      {
+        "name": "Birthday Card",
+        "artist": "Chet Faker",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27359afb3151616a570d357911d",
+        "url": "https://open.spotify.com/track/3Prt3S5X7nsEKv2VARtKrv"
+      },
+      {
+        "name": "By the Way",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273de1af2785a83cc660155a0c4",
+        "url": "https://open.spotify.com/track/1f2V8U1BiWaC9aJWmpOARe"
+      },
+      {
+        "name": "Ladders",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f4101b35799d5966d49025e4",
+        "url": "https://open.spotify.com/track/4HxNX0GQCkdZEDSj6MZZTu"
+      },
+      {
+        "name": "Lovely Day",
+        "artist": "Bill Withers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f8560af696925c50080dcc35",
+        "url": "https://open.spotify.com/track/0ACACkoHUwgfgY5CxVIL4N"
+      },
+      {
+        "name": "Chlorine",
+        "artist": "Twenty One Pilots",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d1d301e737da4324479c6660",
+        "url": "https://open.spotify.com/track/23OXdR7YuUBVWh5hSnYJau"
+      },
+      {
+        "name": "Gimme Gimme - Club Mix",
+        "artist": "Kevin McKay",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27395fdb9b2f3151fe7cecd6147",
+        "url": "https://open.spotify.com/track/7GjZZf77XJYaa5W4S2NbpB"
+      },
+      {
+        "name": "Love$ick (feat. A$AP Rocky)",
+        "artist": "Mura Masa",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2736818aa231aa543cf87e1374a",
+        "url": "https://open.spotify.com/track/3sTN90bIP2cJ1783ctHykO"
+      },
+      {
+        "name": "Acceptable in the 80's",
+        "artist": "Calvin Harris",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d0b33add0e39952e5e721226",
+        "url": "https://open.spotify.com/track/00cxhG668jV6gU6VK2FUVI"
+      },
+      {
+        "name": "Numbers On The Boards",
+        "artist": "Pusha T",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273861ecd2783b33bde98760364",
+        "url": "https://open.spotify.com/track/4XkXgUNDVBMj3oJoE8yspZ"
+      },
+      {
+        "name": "Pursuit Of Happiness (Nightmare)",
+        "artist": "Kid Cudi",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273713f297a7bdc1d48971062b2",
+        "url": "https://open.spotify.com/track/4kTLpAbhuEGHAAdDjOIWaa"
+      },
+      {
+        "name": "Down Under",
+        "artist": "Men At Work",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273aa5e4c9da271951ac0b31fa2",
+        "url": "https://open.spotify.com/track/3ZZq9396zv8pcn5GYVhxUi"
+      },
+      {
+        "name": "Can't Tell Me Nothing",
+        "artist": "Kanye West",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27326f7f19c7f0381e56156c94a",
+        "url": "https://open.spotify.com/track/0mEdbdeRFQwBhN4xfyIeUM"
+      },
+      {
+        "name": "Paranoid",
+        "artist": "Black Sabbath",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273174f71bdda81ecb2eddba01b",
+        "url": "https://open.spotify.com/track/3hwuHzRicnu6Ji9i1JLzor"
+      },
+      {
+        "name": "Dani California",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739eece7a1b7140aaf4056b9b4",
+        "url": "https://open.spotify.com/track/6vODhpvfWwdsO0i9MBWnEq"
+      },
+      {
+        "name": "Find A Way",
+        "artist": "The Kiffness",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273640ed6e4a044f2454a97a1a8",
+        "url": "https://open.spotify.com/track/4RkUA9vPMRHb3kE3N4Hh8h"
+      },
+      {
+        "name": "Pretoria Girls",
+        "artist": "Desmond and the Tutus",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2733bc7729b472abea095fd16ac",
+        "url": "https://open.spotify.com/track/6zkVSIgcGnqromeMTYmXv4"
+      },
+      {
+        "name": "Halcyon Birds",
+        "artist": "Broken Back",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27301e7dc8bb82d8d990a1f0f37",
+        "url": "https://open.spotify.com/track/1WC2ctyzNjpgkhF0dplias"
+      },
+      {
+        "name": "Yellow Mellow",
+        "artist": "Ocean Alley",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27339aae9fd82532542b19c8e60",
+        "url": "https://open.spotify.com/track/6ehgCYEjaYWAYRBVAUEILF"
+      },
+      {
+        "name": "Hey Maria - Elderbrook Remix",
+        "artist": "Klangkarussell",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738f83152c6b30d0e8514df2bc",
+        "url": "https://open.spotify.com/track/7v7teR4FtyiZzkc1tX2a4V"
+      },
+      {
+        "name": "Come As You Are",
+        "artist": "Nirvana",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fbc71c99f9c1296c56dd51b6",
+        "url": "https://open.spotify.com/track/2RsAajgo0g7bMCHxwH3Sk0"
+      },
+      {
+        "name": "Changes - 2015 Remaster",
+        "artist": "David Bowie",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e464904cc3fed2b40fc55120",
+        "url": "https://open.spotify.com/track/0LrwgdLsFaWh9VXIjBRe8t"
+      },
+      {
+        "name": "Seasick Dream",
+        "artist": "Jack Johnson",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d7e40baf75ddce4864c5bc75",
+        "url": "https://open.spotify.com/track/1vL5bZNsFWVYED96IgWEIM"
+      },
+      {
+        "name": "Could You Be Loved",
+        "artist": "Bob Marley & The Wailers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731c40418d1c37d727e8e91b04",
+        "url": "https://open.spotify.com/track/5O4erNlJ74PIF6kGol1ZrC"
+      },
+      {
+        "name": "Seve - Radio Edit",
+        "artist": "Tez Cadey",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273da0751d4a35b6af93fb3e01d",
+        "url": "https://open.spotify.com/track/6UqRGwjwYL0stXbaodTxwo"
+      },
+      {
+        "name": "My Number",
+        "artist": "Foals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738b04dacf186124a62bc667a7",
+        "url": "https://open.spotify.com/track/04caEZhAsQKnWqKsMwk9ud"
+      },
+      {
+        "name": "Because You Move Me",
+        "artist": "Tinlicker",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2730812acbf32441f49383dd27c",
+        "url": "https://open.spotify.com/track/05GvwwTLLID738BbKN1ze0"
+      },
+      {
+        "name": "Are You What You Want to Be?",
+        "artist": "Foster The People",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2737a24cc2f17550f5257409689",
+        "url": "https://open.spotify.com/track/3CVPyuuD6HxWXgPbbGqbg6"
+      },
+      {
+        "name": "THE JUNGLE VIP",
+        "artist": "TREASURE SERIES",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273dde7d7ba131c85bb811dc609",
+        "url": "https://open.spotify.com/track/6Vw61rGpC1JQpBhlxaFbYC"
+      },
+      {
+        "name": "This Song Is Not About A Girl",
+        "artist": "Flume",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273de8b653acb692b4ce30b49a5",
+        "url": "https://open.spotify.com/track/0Z7GNrvgEj3iiIxxPtRwIe"
+      },
+      {
+        "name": "What If I Go? (feat. Bonzai)",
+        "artist": "Mura Masa",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2736818aa231aa543cf87e1374a",
+        "url": "https://open.spotify.com/track/2tHfNQnj50VoMZga2rpfdA"
+      },
+      {
+        "name": "Feels Like a Sunday",
+        "artist": "Elderbrook",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f59d093dc04239c30e32cf49",
+        "url": "https://open.spotify.com/track/2LY14NSmNatgOhdnpdGK8W"
+      },
+      {
+        "name": "Bulletproof",
+        "artist": "La Roux",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27387a7b0bb506cb4416d8f8256",
+        "url": "https://open.spotify.com/track/3kMrazSvILsgcwtidZd1Qd"
+      },
+      {
+        "name": "Sultans Of Swing",
+        "artist": "Dire Straits",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b49d49cc95564aede7998bb8",
+        "url": "https://open.spotify.com/track/37Tmv4NnfQeb0ZgUC4fOJj"
+      },
+      {
+        "name": "Dreams - 2004 Remaster",
+        "artist": "Fleetwood Mac",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e52a59a28efa4773dd2bfe1b",
+        "url": "https://open.spotify.com/track/0ofHAoxe9vBkTCp2UQIavz"
+      },
+      {
+        "name": "I Am the Antichrist to You",
+        "artist": "Kishi Bashi",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c3f7f5abcc43a90cb884fff0",
+        "url": "https://open.spotify.com/track/3tnfHy341CDlAtcSmUtuOG"
+      },
+      {
+        "name": "Stronger",
+        "artist": "Kanye West",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27326f7f19c7f0381e56156c94a",
+        "url": "https://open.spotify.com/track/0j2T0R9dR9qdJYsB7ciXhf"
+      }
+    ]
   }
 }

--- a/src/data/wrapped/2022.json
+++ b/src/data/wrapped/2022.json
@@ -1685,5 +1685,411 @@
     "returningCount": 19,
     "newCount": 1,
     "returningPct": 95
+  },
+  "apiSnapshot": {
+    "topArtists": [
+      {
+        "name": "Red Hot Chili Peppers",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc33cc15260b767ddec982ce8",
+        "url": "https://open.spotify.com/artist/0L8ExT028jH3ddEcZwqJJ5"
+      },
+      {
+        "name": "Mac Miller",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebed3b89aa602145fde71a163a",
+        "url": "https://open.spotify.com/artist/4LLpKhyESsyAXpc4laK94U"
+      },
+      {
+        "name": "Black Sabbath",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb4870cd833ebe1092601820c3",
+        "url": "https://open.spotify.com/artist/5M52tdBnJaKSvOpJGz8mfZ"
+      },
+      {
+        "name": "Kanye West",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb6e835a500e791bf9c27a422a",
+        "url": "https://open.spotify.com/artist/5K4W6rqBFWDnAN6FQUkS6x"
+      },
+      {
+        "name": "Led Zeppelin",
+        "image": "https://i.scdn.co/image/207803ce008388d3427a685254f9de6a8f61dc2e",
+        "url": "https://open.spotify.com/artist/36QJpDe2go2KgaRleHCDTp"
+      },
+      {
+        "name": "Kendrick Lamar",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb39ba6dcd4355c03de0b50918",
+        "url": "https://open.spotify.com/artist/2YZyLoL8N0Wb9xBt1NhZWg"
+      },
+      {
+        "name": "Rodríguez",
+        "image": "https://i.scdn.co/image/d1d0f4b212e16eb6bf079e8e7bae11828378a2bc",
+        "url": "https://open.spotify.com/artist/5PrHzxc3kFm4hIrGNmelpX"
+      },
+      {
+        "name": "Milky Chance",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb23eb1af2ef13c5db234ff824",
+        "url": "https://open.spotify.com/artist/1hzfo8twXdOegF3xireCYs"
+      },
+      {
+        "name": "DOPE LEMON",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb08d96270687870e07c667bdd",
+        "url": "https://open.spotify.com/artist/7oZLKL1GjYiaAgssXsLmW8"
+      },
+      {
+        "name": "MGMT",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb9dccdc8f4087cbe2bdedc9d3",
+        "url": "https://open.spotify.com/artist/0SwO7SWeDHJijQ3XNS7xEE"
+      },
+      {
+        "name": "Foals",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb5f0109249ffd70b2d85a9467",
+        "url": "https://open.spotify.com/artist/6FQqZYVfTNQ1pCqfkwVFEa"
+      },
+      {
+        "name": "Twenty One Pilots",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb61a7ea26d33ded218cd1e59d",
+        "url": "https://open.spotify.com/artist/3YQKmKGau1PzlVlkL1iodx"
+      },
+      {
+        "name": "Kid Cudi",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb5f00bb6dd7a7008d14156630",
+        "url": "https://open.spotify.com/artist/0fA0VVWsXO9YnASrzqfmYu"
+      },
+      {
+        "name": "The Jungle Giants",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb0917fdf7d54dd23b78f97a29",
+        "url": "https://open.spotify.com/artist/6wFwvxJkurQPU2UdeD4qVt"
+      },
+      {
+        "name": "Chance the Rapper",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebd4d18d62a36a26fe36b70e2a",
+        "url": "https://open.spotify.com/artist/1anyVhU62p31KFi8MEzkbf"
+      },
+      {
+        "name": "Lynyrd Skynyrd",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb3f02c2ff7ea1aa208e015f57",
+        "url": "https://open.spotify.com/artist/4MVyzYMgTwdP7Z49wAZHx0"
+      },
+      {
+        "name": "Calvin Harris",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb8ebba5e60113b48de8c11f6b",
+        "url": "https://open.spotify.com/artist/7CajNmpbOovFoOoasH2HaY"
+      },
+      {
+        "name": "Chet Faker",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb887f380a1d6fafe95238c86b",
+        "url": "https://open.spotify.com/artist/6UcJxoeHWWWyT5HZP064om"
+      },
+      {
+        "name": "Queen",
+        "image": "https://i.scdn.co/image/ab6772690000dd2247488c35a509d42072c23976",
+        "url": "https://open.spotify.com/artist/1dfeR4HaWDbWqFHLkxsg1d"
+      },
+      {
+        "name": "AC/DC",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc4c77549095c86acb4e77b37",
+        "url": "https://open.spotify.com/artist/711MCceyCBcFnzjGY4Q7Un"
+      }
+    ],
+    "topTracks": [
+      {
+        "name": "Snow (Hey Oh)",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/2aibwv5hGXSgw7Yru8IYTO"
+      },
+      {
+        "name": "Under the Bridge",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2735590b4ee88187cb06a5b102d",
+        "url": "https://open.spotify.com/track/23NPGXlSaIqWzvxIRhM2oG"
+      },
+      {
+        "name": "Birthday Card",
+        "artist": "Chet Faker",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27359afb3151616a570d357911d",
+        "url": "https://open.spotify.com/track/3Prt3S5X7nsEKv2VARtKrv"
+      },
+      {
+        "name": "Sabbath Bloody Sabbath",
+        "artist": "Black Sabbath",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273174f71bdda81ecb2eddba01b",
+        "url": "https://open.spotify.com/track/0EDeh0yFVKQZZQoJ1AVw3Z"
+      },
+      {
+        "name": "Burning",
+        "artist": "The Whitest Boy Alive",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27354405f4e966b1efbebb88883",
+        "url": "https://open.spotify.com/track/0QgR03vMDoBoLgcu08EtKl"
+      },
+      {
+        "name": "Hard to Concentrate",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/37kTASujIfZZ27NV7PfIrf"
+      },
+      {
+        "name": "Electric Feel",
+        "artist": "MGMT",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738b32b139981e79f2ebe005eb",
+        "url": "https://open.spotify.com/track/3FtYbEfBqAlGO46NUDQSAt"
+      },
+      {
+        "name": "Walking On A Dream",
+        "artist": "Empire Of The Sun",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273147fd9fbc3cfd8dd10002f41",
+        "url": "https://open.spotify.com/track/3xVaJfd27n4S6ZZoyGYX4H"
+      },
+      {
+        "name": "All Along the Watchtower",
+        "artist": "Jimi Hendrix",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273522088789d49e216d9818292",
+        "url": "https://open.spotify.com/track/2aoo2jlRnM3A0NyLQqMN2f"
+      },
+      {
+        "name": "Giant (with Rag'n'Bone Man)",
+        "artist": "Calvin Harris",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a9a9d8a16c0b4146fb707c02",
+        "url": "https://open.spotify.com/track/5itOtNx0WxtJmi1TQ3RuRd"
+      },
+      {
+        "name": "Don't Start Now",
+        "artist": "Dua Lipa",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273252ba339f802d9cf88122757",
+        "url": "https://open.spotify.com/track/6WrI0LAC5M1Rw2MnX2ZvEg"
+      },
+      {
+        "name": "Sweet Disposition",
+        "artist": "The Temper Trap",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273752b549c65bf5333612f554a",
+        "url": "https://open.spotify.com/track/1jUkHIMc7UaJQuzWe5Iop2"
+      },
+      {
+        "name": "Kudaushe",
+        "artist": "Afriquoi",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27365d5ab5efb4af4e98377ddb4",
+        "url": "https://open.spotify.com/track/7hGidl99Umesys0O0CzXTS"
+      },
+      {
+        "name": "Fisher",
+        "artist": "Camel Power Club",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ef37cdb360df67bba78f3510",
+        "url": "https://open.spotify.com/track/3cY2nHVVX2ZER1ttxGzLav"
+      },
+      {
+        "name": "By the Way",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273de1af2785a83cc660155a0c4",
+        "url": "https://open.spotify.com/track/1f2V8U1BiWaC9aJWmpOARe"
+      },
+      {
+        "name": "Monarchy of Roses",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27396136a2ab5696812e9b26723",
+        "url": "https://open.spotify.com/track/16Bf9uR4PI2dCoXDIjs0cP"
+      },
+      {
+        "name": "Simple Man",
+        "artist": "Lynyrd Skynyrd",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273128450651c9f0442780d8eb8",
+        "url": "https://open.spotify.com/track/1ju7EsSGvRybSNEsRvc7qY"
+      },
+      {
+        "name": "Charlie",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/3SoDB59Y7dSZLSDBiNJ6o2"
+      },
+      {
+        "name": "Scar Tissue",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a9249ebb15ca7a5b75f16a90",
+        "url": "https://open.spotify.com/track/2QOMGq8wVTZbLmh7McrvgF"
+      },
+      {
+        "name": "Tuyo (Narcos Theme) [Extended Version] - A Netflix Original Series Soundtrack",
+        "artist": "Rodrigo Amarante",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27364d924aebcb26f08aac1bf3b",
+        "url": "https://open.spotify.com/track/6g2BiiVQqY5v1S4HIrM54F"
+      },
+      {
+        "name": "Pursuit Of Happiness (Nightmare)",
+        "artist": "Kid Cudi",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273713f297a7bdc1d48971062b2",
+        "url": "https://open.spotify.com/track/4kTLpAbhuEGHAAdDjOIWaa"
+      },
+      {
+        "name": "Afro Sambroso - Rampa Version",
+        "artist": "Lokkhi Terra",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e931b2ca5e035832ce4af5d5",
+        "url": "https://open.spotify.com/track/23IBJoNkMZNL286OoJobc9"
+      },
+      {
+        "name": "My Number",
+        "artist": "Foals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738b04dacf186124a62bc667a7",
+        "url": "https://open.spotify.com/track/04caEZhAsQKnWqKsMwk9ud"
+      },
+      {
+        "name": "Africa",
+        "artist": "TOTO",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ebd6d20c0082524244ef83df",
+        "url": "https://open.spotify.com/track/2374M0fQpWi3dLnB54qaLX"
+      },
+      {
+        "name": "Hey",
+        "artist": "Pixies",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2730ab3c2a306c614fae36ff1d6",
+        "url": "https://open.spotify.com/track/0p5eZCY0R7uNCZS1YDtIYI"
+      },
+      {
+        "name": "Paranoid",
+        "artist": "Black Sabbath",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273174f71bdda81ecb2eddba01b",
+        "url": "https://open.spotify.com/track/3hwuHzRicnu6Ji9i1JLzor"
+      },
+      {
+        "name": "Ramble On - 1990 Remaster",
+        "artist": "Led Zeppelin",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fc4f17340773c6c3579fea0d",
+        "url": "https://open.spotify.com/track/3MODES4TNtygekLl146Dxd"
+      },
+      {
+        "name": "Birch Tree",
+        "artist": "Foals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b036f68e97ce9f5372bfb350",
+        "url": "https://open.spotify.com/track/0BPKqNWOKQam19tKWoZQwu"
+      },
+      {
+        "name": "Never Fight A Man With A Perm",
+        "artist": "IDLES",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f247f4e8334b745fc2dd080f",
+        "url": "https://open.spotify.com/track/5DrkhJaGka08ZK6QyuMK0W"
+      },
+      {
+        "name": "A National Acrobat",
+        "artist": "Black Sabbath",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e3eaed3e5895ca02d5b6a868",
+        "url": "https://open.spotify.com/track/6iJuDBangLQkI7cc9MdjPw"
+      },
+      {
+        "name": "Slow Cheetah",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/06wTEKL2rSrSaOjFtgG8fj"
+      },
+      {
+        "name": "What Went Down",
+        "artist": "Foals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b036f68e97ce9f5372bfb350",
+        "url": "https://open.spotify.com/track/78tgXRq9Q6tPNP9hKCpgwB"
+      },
+      {
+        "name": "Lithium",
+        "artist": "Nirvana",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fbc71c99f9c1296c56dd51b6",
+        "url": "https://open.spotify.com/track/5vHLwhxxlGzmClMcxRRFPr"
+      },
+      {
+        "name": "Cabron",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273de1af2785a83cc660155a0c4",
+        "url": "https://open.spotify.com/track/5TGYo4MrNKqIvJqgx134py"
+      },
+      {
+        "name": "My Friends",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2737f3dcf99224570b053294ccf",
+        "url": "https://open.spotify.com/track/6HksxcBzMVdT17aq1Q79Xe"
+      },
+      {
+        "name": "Meet Me At Our Spot",
+        "artist": "THE ANXIETY",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273024ea7e883a713a3ad552a71",
+        "url": "https://open.spotify.com/track/07MDkzWARZaLEdKxo6yArG"
+      },
+      {
+        "name": "Seven Nation Army",
+        "artist": "The White Stripes",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2737028981d09d2e5833c9c78ad",
+        "url": "https://open.spotify.com/track/3dPQuX8Gs42Y7b454ybpMR"
+      },
+      {
+        "name": "Wet Sand",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/3L2Nyi3T7XabH8EEZFLDdX"
+      },
+      {
+        "name": "DRUGS",
+        "artist": "Tai Verdes",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c7cce3cefa0194e71a2b2cac",
+        "url": "https://open.spotify.com/track/4tVASOccgcigdCfwUamZCh"
+      },
+      {
+        "name": "Pretoria Girls",
+        "artist": "Desmond and the Tutus",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2733bc7729b472abea095fd16ac",
+        "url": "https://open.spotify.com/track/6zkVSIgcGnqromeMTYmXv4"
+      },
+      {
+        "name": "Yellow Mellow",
+        "artist": "Ocean Alley",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27339aae9fd82532542b19c8e60",
+        "url": "https://open.spotify.com/track/6ehgCYEjaYWAYRBVAUEILF"
+      },
+      {
+        "name": "Sundress",
+        "artist": "A$AP Rocky",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731ae967e4a02c7a39eb3c189b",
+        "url": "https://open.spotify.com/track/2aPTvyE09vUCRwVvj0I8WK"
+      },
+      {
+        "name": "1901 - triple j Like a Version",
+        "artist": "Petit Biscuit",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731e3b7405538d168e44ebd52f",
+        "url": "https://open.spotify.com/track/1veoDetf6j2l5apdLpBYYX"
+      },
+      {
+        "name": "Ladders",
+        "artist": "Mac Miller",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f4101b35799d5966d49025e4",
+        "url": "https://open.spotify.com/track/4HxNX0GQCkdZEDSj6MZZTu"
+      },
+      {
+        "name": "Dove",
+        "artist": "Cymande",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273dac65c0288bb956396671950",
+        "url": "https://open.spotify.com/track/4xnyBIfiVgT7ZjrHGdrHtw"
+      },
+      {
+        "name": "Crucify Your Mind",
+        "artist": "Rodríguez",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e7e1b574a9e6b9f26c7c3f49",
+        "url": "https://open.spotify.com/track/2Xn7NadvZ56D0B2D7x2CSL"
+      },
+      {
+        "name": "Lovely Day",
+        "artist": "Bill Withers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f8560af696925c50080dcc35",
+        "url": "https://open.spotify.com/track/0ACACkoHUwgfgY5CxVIL4N"
+      },
+      {
+        "name": "Highway Tune",
+        "artist": "Greta Van Fleet",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d79ec58f261735f73a28f6b4",
+        "url": "https://open.spotify.com/track/1S3V5gvuLYt2Nabd3vVz1f"
+      },
+      {
+        "name": "Grizzly Bear",
+        "artist": "Angus & Julia Stone",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738a4409496dc76a5637e40840",
+        "url": "https://open.spotify.com/track/0IJ1ijo3uoJzy6ZE5wxJio"
+      },
+      {
+        "name": "Give a Little Love",
+        "artist": "Gizmo Varillas",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b363433d9507c5740d35fcb4",
+        "url": "https://open.spotify.com/track/0CQ6cbXPUsB9NcJZ2Abuc4"
+      }
+    ]
   }
 }

--- a/src/data/wrapped/2023.json
+++ b/src/data/wrapped/2023.json
@@ -1681,5 +1681,411 @@
     "returningCount": 19,
     "newCount": 1,
     "returningPct": 95
+  },
+  "apiSnapshot": {
+    "topArtists": [
+      {
+        "name": "Red Hot Chili Peppers",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Glass Animals",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Mac Miller",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Kid Cudi",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "MGMT",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Kanye West",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Johnny Clegg & Juluka",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Bob Marley & The Wailers",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Milky Chance",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Fleetwood Mac",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Empire Of The Sun",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Frank Ocean",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "GoldFish",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Desmond and the Tutus",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "J. Cole",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Led Zeppelin",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Black Sabbath",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "The Jungle Giants",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Queen",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Kendrick Lamar",
+        "image": "",
+        "url": ""
+      }
+    ],
+    "topTracks": [
+      {
+        "name": "The Ship",
+        "artist": "Incredible Polo",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1WpCorgdzT5RzNfjbudcms"
+      },
+      {
+        "name": "Lost",
+        "artist": "Frank Ocean",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3GZD6HmiNUhxXYf8Gch723"
+      },
+      {
+        "name": "Walking On A Dream",
+        "artist": "Empire Of The Sun",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0mBkoM8r7KAQzZij5swTUL"
+      },
+      {
+        "name": "Love Lost",
+        "artist": "Mac Miller",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0N9C80kcgL0xXGduKnYKWi"
+      },
+      {
+        "name": "Electric Feel",
+        "artist": "MGMT",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3FtYbEfBqAlGO46NUDQSAt"
+      },
+      {
+        "name": "Pursuit Of Happiness (Nightmare)",
+        "artist": "Kid Cudi",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4kTLpAbhuEGHAAdDjOIWaa"
+      },
+      {
+        "name": "The Spins",
+        "artist": "Mac Miller",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/51pshtuYkgUQnt5huMPbKL"
+      },
+      {
+        "name": "Youth",
+        "artist": "Glass Animals",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1LPGwuFgIzbJoShfDdw7MY"
+      },
+      {
+        "name": "The Thrill",
+        "artist": "Wiz Khalifa",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/56oGoEjA9eTZYgsttEFKY3"
+      },
+      {
+        "name": "Pools",
+        "artist": "Glass Animals",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7jO2B8Xgfu7D9vj60XiG7Y"
+      },
+      {
+        "name": "Heat Waves",
+        "artist": "Glass Animals",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6CDzDgIUqeDY5g8ujExx2f"
+      },
+      {
+        "name": "Sundress",
+        "artist": "A$AP Rocky",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2aPTvyE09vUCRwVvj0I8WK"
+      },
+      {
+        "name": "Hold On",
+        "artist": "SBTRKT",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/47GsUibP7RiUL7SQ7YFfhu"
+      },
+      {
+        "name": "Snow (Hey Oh)",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2aibwv5hGXSgw7Yru8IYTO"
+      },
+      {
+        "name": "Sweet Disposition",
+        "artist": "The Temper Trap",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4t40FO2bd8WoJ3VN0h95fj"
+      },
+      {
+        "name": "Magic In The Hamptons (feat. Lil Yachty)",
+        "artist": "Social House",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2Yer0p7uB2lVBUAtANuuQp"
+      },
+      {
+        "name": "3 Nights",
+        "artist": "Dominic Fike",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1tNJrcVe6gwLEiZCtprs1u"
+      },
+      {
+        "name": "Warm Blindness & A Cool Breeze",
+        "artist": "Calvin Love",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4IWc2mRSxudrK5BPjHl8AQ"
+      },
+      {
+        "name": "Tongues",
+        "artist": "Joywave",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5mCprFWOqe0jB96v9RhLBo"
+      },
+      {
+        "name": "Kids",
+        "artist": "MGMT",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1jJci4qxiYcOHhQR247rEU"
+      },
+      {
+        "name": "Under the Bridge",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3d9DChrdc6BOeFsbrZ3Is0"
+      },
+      {
+        "name": "The Sun",
+        "artist": "Myd",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5UEZzRsrB4FKw1SIMoMD2y"
+      },
+      {
+        "name": "Walima 'Mabele",
+        "artist": "Johnny Clegg & Juluka",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1QxHsUiOaSuhKbbjt6OQaj"
+      },
+      {
+        "name": "Give a Little Love",
+        "artist": "Gizmo Varillas",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0CQ6cbXPUsB9NcJZ2Abuc4"
+      },
+      {
+        "name": "Miracle Mile",
+        "artist": "Cold War Kids",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7lMQmn9eXfnUwkrYcpHwvr"
+      },
+      {
+        "name": "Mr. Rager",
+        "artist": "Kid Cudi",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/393MDhe62s8hbH8ETrlxe5"
+      },
+      {
+        "name": "8TEEN",
+        "artist": "Khalid",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5bgwqaRSS3M8WHWruHgSL5"
+      },
+      {
+        "name": "Close These Curtains - Stimming Remix",
+        "artist": "Yoko Duo",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0ZYQ8J5CmB7EBnFCWwZfaG"
+      },
+      {
+        "name": "Africa",
+        "artist": "TOTO",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2374M0fQpWi3dLnB54qaLX"
+      },
+      {
+        "name": "Franzis",
+        "artist": "FIL BO RIVA",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5veNqlivxPp7aHILe5d05a"
+      },
+      {
+        "name": "Young Folks",
+        "artist": "Peter Bjorn and John",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4dyx5SzxPPaD8xQIid5Wjj"
+      },
+      {
+        "name": "Scar Tissue",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1G391cbiT3v3Cywg8T7DM1"
+      },
+      {
+        "name": "This Must Be the Place (Naive Melody) - 2005 Remaster",
+        "artist": "Talking Heads",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6aBUnkXuCEQQHAlTokv9or"
+      },
+      {
+        "name": "Fisher",
+        "artist": "Camel Power Club",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3cY2nHVVX2ZER1ttxGzLav"
+      },
+      {
+        "name": "World Hold On - FISHER Rework",
+        "artist": "Bob Sinclar",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2YDOjCfkGciEXxSutB6LJR"
+      },
+      {
+        "name": "Laps Around The Sun",
+        "artist": "Ziggy Alberts",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3U0UzEdzd45T81FHdPPbfC"
+      },
+      {
+        "name": "Punky Reggae Party - 12\" Version",
+        "artist": "Bob Marley & The Wailers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6L4g3GDDQnbwo9fqPyv0AZ"
+      },
+      {
+        "name": "The Forgotten People",
+        "artist": "BehrEllips",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0fpKHYhMTq4bSZQ5aukuAl"
+      },
+      {
+        "name": "Dreams - 2004 Remaster",
+        "artist": "Fleetwood Mac",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0ofHAoxe9vBkTCp2UQIavz"
+      },
+      {
+        "name": "Scatterlings Of Africa",
+        "artist": "Johnny Clegg & Juluka",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7susV8wUCiADZTz21j4QXU"
+      },
+      {
+        "name": "Everywhere",
+        "artist": "Fleetwood Mac",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1prZ0pr6XoRCxcrC3MCL0M"
+      },
+      {
+        "name": "Spiderhead",
+        "artist": "Cage The Elephant",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4FN395EYfdCGrBthUfJzug"
+      },
+      {
+        "name": "mr. sunshine",
+        "artist": "Arden Jones",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6x984mI891z1E2sVwYumUx"
+      },
+      {
+        "name": "B.O.T.A. (Baddest Of Them All) - Edit",
+        "artist": "Eliza Rose",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/39JofJHEtg8I4fSyo7Imft"
+      },
+      {
+        "name": "No Lie",
+        "artist": "Sean Paul",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/48QmG1dfvMuYLxMPt7KSRA"
+      },
+      {
+        "name": "Distant Past",
+        "artist": "Everything Everything",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4L2F0LcDVtNrFc1K4lmx3m"
+      },
+      {
+        "name": "Younger - Kygo Remix",
+        "artist": "Seinabo Sey",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7vHshinTU8161w69EPbabY"
+      },
+      {
+        "name": "Give Me Sunshine - Niklas Ibach Remix",
+        "artist": "Santa Maradona F.C.",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5DLhx2Jp41TycsjTxcwrv2"
+      },
+      {
+        "name": "Call Me In The Afternoon",
+        "artist": "Half Moon Run",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5vVHhJr6OpVuHMt1TuHT35"
+      },
+      {
+        "name": "Relax My Eyes",
+        "artist": "ANOTR",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5u4hhtZ7f4rWkMZEZcTKrH"
+      }
+    ]
   }
 }

--- a/src/data/wrapped/2024.json
+++ b/src/data/wrapped/2024.json
@@ -1661,5 +1661,411 @@
     "returningCount": 15,
     "newCount": 5,
     "returningPct": 75
+  },
+  "apiSnapshot": {
+    "topArtists": [
+      {
+        "name": "Red Hot Chili Peppers",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc33cc15260b767ddec982ce8",
+        "url": "https://open.spotify.com/artist/0L8ExT028jH3ddEcZwqJJ5"
+      },
+      {
+        "name": "andhim",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebd7d74c48f97de722a7871d9f",
+        "url": "https://open.spotify.com/artist/6XJeFzmI6vrWyHcdB7EImP"
+      },
+      {
+        "name": "Super Flu",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb61cbdc6dea665ca3c3142c98",
+        "url": "https://open.spotify.com/artist/1iZiG82D4w7FLHvOUUj4zW"
+      },
+      {
+        "name": "The Rolling Stones",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebe4cea917b68726aadb4854b8",
+        "url": "https://open.spotify.com/artist/22bE4uQ6baNwSHPVcDxLCe"
+      },
+      {
+        "name": "Bob Marley & The Wailers",
+        "image": "https://i.scdn.co/image/4cd57e5e12ea2c24644c40886d65a9b22eca9802",
+        "url": "https://open.spotify.com/artist/2QsynagSdAqZj3U9HgDzjD"
+      },
+      {
+        "name": "Kölsch",
+        "image": "https://i.scdn.co/image/ab6761610000e5eba50059967122d0f2609b2e82",
+        "url": "https://open.spotify.com/artist/2D9Oe8R9UhbMvFAsMJpXj0"
+      },
+      {
+        "name": "HVOB",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb4432398038a3f585dd92165b",
+        "url": "https://open.spotify.com/artist/6RAx8RRxoHeJIqD2d0EjOa"
+      },
+      {
+        "name": "Yoko Duo",
+        "image": "https://i.scdn.co/image/8f0509e6196ee2d1f64e05ae5fafc6f424749998",
+        "url": "https://open.spotify.com/artist/3qS9rCN3k1e6uBRYzuxqAf"
+      },
+      {
+        "name": "Metallica",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb69ca98dd3083f1082d740e44",
+        "url": "https://open.spotify.com/artist/2ye2Wgw4gimLv2eAKyk1NB"
+      },
+      {
+        "name": "Milky Chance",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb23eb1af2ef13c5db234ff824",
+        "url": "https://open.spotify.com/artist/1hzfo8twXdOegF3xireCYs"
+      },
+      {
+        "name": "Fleetwood Mac",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc8752dd511cda8c31e9daee8",
+        "url": "https://open.spotify.com/artist/08GQAI4eElDnROBrJRGE0X"
+      },
+      {
+        "name": "Led Zeppelin",
+        "image": "https://i.scdn.co/image/207803ce008388d3427a685254f9de6a8f61dc2e",
+        "url": "https://open.spotify.com/artist/36QJpDe2go2KgaRleHCDTp"
+      },
+      {
+        "name": "AC/DC",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc4c77549095c86acb4e77b37",
+        "url": "https://open.spotify.com/artist/711MCceyCBcFnzjGY4Q7Un"
+      },
+      {
+        "name": "Kanye West",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb6e835a500e791bf9c27a422a",
+        "url": "https://open.spotify.com/artist/5K4W6rqBFWDnAN6FQUkS6x"
+      },
+      {
+        "name": "Maribou State",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb8226ea46d749763f4e650015",
+        "url": "https://open.spotify.com/artist/7zrkALJ9ayRjzysp4QYoEg"
+      },
+      {
+        "name": "Zach Bryan",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebc742fbc057bdbc64834a6cdc",
+        "url": "https://open.spotify.com/artist/40ZNYROS4zLfyyBSs2PGe2"
+      },
+      {
+        "name": "Creedence Clearwater Revival",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebd2e2b04b7ba5d60b72f54506",
+        "url": "https://open.spotify.com/artist/3IYUhFvPQItj6xySrBmZkd"
+      },
+      {
+        "name": "Calvin Harris",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb8ebba5e60113b48de8c11f6b",
+        "url": "https://open.spotify.com/artist/7CajNmpbOovFoOoasH2HaY"
+      },
+      {
+        "name": "Paul Kalkbrenner",
+        "image": "https://i.scdn.co/image/ab6761610000e5ebb72a52d500aa9e245f9ee6a1",
+        "url": "https://open.spotify.com/artist/0rasA5Z5h1ITtHelCpfu9R"
+      },
+      {
+        "name": "MGMT",
+        "image": "https://i.scdn.co/image/ab6761610000e5eb9dccdc8f4087cbe2bdedc9d3",
+        "url": "https://open.spotify.com/artist/0SwO7SWeDHJijQ3XNS7xEE"
+      }
+    ],
+    "topTracks": [
+      {
+        "name": "Steal",
+        "artist": "Maribou State",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2733beca4a9acadd343338a8356",
+        "url": "https://open.spotify.com/track/0pAiyIHt9DyHOjWgF41kp6"
+      },
+      {
+        "name": "Always Like This - andhim Remix",
+        "artist": "HVOB",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273bfdbe667065c009d5d2f5693",
+        "url": "https://open.spotify.com/track/2Gzl0HAOGySuLysalinVP4"
+      },
+      {
+        "name": "Evergreen",
+        "artist": "Richy Mitch & The Coal Miners",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731cc17bae5ee17cce117e198a",
+        "url": "https://open.spotify.com/track/6me7F0aaZjwDo6RJ5MrfBD"
+      },
+      {
+        "name": "Wine & Chocolates - andhim Remix Radio Version",
+        "artist": "Theophilus London",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731b9c45dad7e1a68482483cd7",
+        "url": "https://open.spotify.com/track/0qsQZDAZIGsbGmYEMfhTSC"
+      },
+      {
+        "name": "Close These Curtains - Stimming Remix",
+        "artist": "Yoko Duo",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c55f08045aa2b4df4684b59d",
+        "url": "https://open.spotify.com/track/0ZYQ8J5CmB7EBnFCWwZfaG"
+      },
+      {
+        "name": "For Whom The Bell Tolls - Remastered",
+        "artist": "Metallica",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739ad3e9959f48d513886b8933",
+        "url": "https://open.spotify.com/track/2dXsILW8gzkosqleHAvl0v"
+      },
+      {
+        "name": "How Many Times",
+        "artist": "andhim",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e8f4c6a910aa34aedbaab1d0",
+        "url": "https://open.spotify.com/track/2hA4CSHqDDANsdPFuuWVd4"
+      },
+      {
+        "name": "6 Degrees - Tale Of Us Remix",
+        "artist": "Audiofly",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273bce5cc7c484b56dd209fc164",
+        "url": "https://open.spotify.com/track/3iEEFmpTWM5iX7IPYQpcp7"
+      },
+      {
+        "name": "Goldfisch",
+        "artist": "Kölsch",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273510fe49b1a60e733c4a37a52",
+        "url": "https://open.spotify.com/track/7gwB872zS8guMxYTyQSwxY"
+      },
+      {
+        "name": "Awake - Agoria Remix",
+        "artist": "Santé",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fcab821a72fa69b7349c5db4",
+        "url": "https://open.spotify.com/track/3oBTlRetzuXuE6mUGnX0Z1"
+      },
+      {
+        "name": "Electric Feel",
+        "artist": "MGMT",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2738b32b139981e79f2ebe005eb",
+        "url": "https://open.spotify.com/track/3FtYbEfBqAlGO46NUDQSAt"
+      },
+      {
+        "name": "Feeling",
+        "artist": "&ME",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27394f73cc4dea6b24931f08c61",
+        "url": "https://open.spotify.com/track/3TyPz3L5D2lWncHNYVbzSM"
+      },
+      {
+        "name": "Can't Stop",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fdbcee40748537ff80a7af70",
+        "url": "https://open.spotify.com/track/4BcS4LomxUnQpzx4hCaJTs"
+      },
+      {
+        "name": "All that matters - andhim Mix",
+        "artist": "Kölsch",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27323bf0c5443dfd945a3b521dc",
+        "url": "https://open.spotify.com/track/051zqeVJo3v8Z6CP8Mrpkt"
+      },
+      {
+        "name": "Beast Of Burden - Remastered 1994",
+        "artist": "The Rolling Stones",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27305c7aec05eabf142cc33b936",
+        "url": "https://open.spotify.com/track/77oU2rjC5XbjQfNe3bD6so"
+      },
+      {
+        "name": "Boy Boy Boy",
+        "artist": "andhim",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f325f76b65e8cb1f3096e6d3",
+        "url": "https://open.spotify.com/track/6NFbXVo5s7A4Gq4YPrmHXv"
+      },
+      {
+        "name": "Dreams - 2004 Remaster",
+        "artist": "Fleetwood Mac",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e52a59a28efa4773dd2bfe1b",
+        "url": "https://open.spotify.com/track/0ofHAoxe9vBkTCp2UQIavz"
+      },
+      {
+        "name": "Volkwein",
+        "artist": "Super Flu",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273b84e9566acc1bfb8c41c0eaa",
+        "url": "https://open.spotify.com/track/7vbXuqIZe5ghKwJtaYxqM8"
+      },
+      {
+        "name": "Plätscher",
+        "artist": "Paul Kalkbrenner",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273cc34c8b86f8bca9ded345b31",
+        "url": "https://open.spotify.com/track/4fBHiFOlhyuQ5yFcUIAKmP"
+      },
+      {
+        "name": "Sex on Fire",
+        "artist": "Kings of Leon",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2732519d01c0cca06f134eeadd8",
+        "url": "https://open.spotify.com/track/0ntQJM78wzOLVeCUAW7Y45"
+      },
+      {
+        "name": "Too Sweet",
+        "artist": "Hozier",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273be392334d99f82bc410cb239",
+        "url": "https://open.spotify.com/track/3HMY0r2BAdpasXMY8rseR0"
+      },
+      {
+        "name": "Lost",
+        "artist": "Frank Ocean",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2737aede4855f6d0d738012e2e5",
+        "url": "https://open.spotify.com/track/3GZD6HmiNUhxXYf8Gch723"
+      },
+      {
+        "name": "Snow (Hey Oh)",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27309fd83d32aee93dceba78517",
+        "url": "https://open.spotify.com/track/2aibwv5hGXSgw7Yru8IYTO"
+      },
+      {
+        "name": "Have You Ever Seen The Rain",
+        "artist": "Creedence Clearwater Revival",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739b7a4a59ac03447db7491f37",
+        "url": "https://open.spotify.com/track/5DnT9a5IM3eMjKgXTWVJvi"
+      },
+      {
+        "name": "Oysters In My Pocket",
+        "artist": "Royel Otis",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27343e43cc5bad5dcb157ee3609",
+        "url": "https://open.spotify.com/track/2B664ulJSVBd6B8SAY3Wux"
+      },
+      {
+        "name": "Woohoo",
+        "artist": "HOSH",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b27313ac40127f73fd265b72dece",
+        "url": "https://open.spotify.com/track/1Obdj4uLPjDEULBMHpXRDX"
+      },
+      {
+        "name": "Be Good - Andhim Remix",
+        "artist": "Hanne & Lore",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273cbeb80bddff5cedd4c2d530d",
+        "url": "https://open.spotify.com/track/2Otkx7WojuKQ8uyvTVLeyP"
+      },
+      {
+        "name": "What I Might Do",
+        "artist": "Ben Pearce",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273f0a5687d62225e9315d4c713",
+        "url": "https://open.spotify.com/track/7tkqhfJlKtZvs3nf9kVJCz"
+      },
+      {
+        "name": "Scar Tissue",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a9249ebb15ca7a5b75f16a90",
+        "url": "https://open.spotify.com/track/2QOMGq8wVTZbLmh7McrvgF"
+      },
+      {
+        "name": "Can't Do Without You - Tale of Us & Mano Le Tough Remix",
+        "artist": "Caribou",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2739caa3b860148d3ebcf69d5ae",
+        "url": "https://open.spotify.com/track/26JOdLAIiuUHnV3aGf2EeJ"
+      },
+      {
+        "name": "Far Away Place - Rampa Remix",
+        "artist": "Xinobi",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2732f6c2253ef0e3ac14aec9e0d",
+        "url": "https://open.spotify.com/track/4SpESjSScmJyuMamD9MKOL"
+      },
+      {
+        "name": "Paranoid - 2009 Remaster",
+        "artist": "Black Sabbath",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273605b25c031f809d78054a13c",
+        "url": "https://open.spotify.com/track/3Jnxngdff0lVu2rza1GVx6"
+      },
+      {
+        "name": "Fortunate Son",
+        "artist": "Creedence Clearwater Revival",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e88774c6adcd5b8cce420d0c",
+        "url": "https://open.spotify.com/track/5DSfAqZ5YjOMf4C0Elvpa0"
+      },
+      {
+        "name": "Walking On A Dream",
+        "artist": "Empire Of The Sun",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273147fd9fbc3cfd8dd10002f41",
+        "url": "https://open.spotify.com/track/3xVaJfd27n4S6ZZoyGYX4H"
+      },
+      {
+        "name": "Pumped Up Kicks",
+        "artist": "Foster The People",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273121d5f92cf90576907dfb1e5",
+        "url": "https://open.spotify.com/track/7w87IxuO7BDcJ3YUqCyMTT"
+      },
+      {
+        "name": "Mr. Bass",
+        "artist": "andhim",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273d9d82aaa49c16040729e8bf6",
+        "url": "https://open.spotify.com/track/3UiacgoMyh8LVr8C5qMKGW"
+      },
+      {
+        "name": "Brown Eyed Girl",
+        "artist": "Van Morrison",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a145a9479143ec784e2db548",
+        "url": "https://open.spotify.com/track/4CNL4GBNTdVIU5Nk6hB4LC"
+      },
+      {
+        "name": "3 Nights",
+        "artist": "Dominic Fike",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2737b1b6f41c1645af9757d5616",
+        "url": "https://open.spotify.com/track/0uI7yAKUf52Cn7y3sYyjiX"
+      },
+      {
+        "name": "Youth",
+        "artist": "Glass Animals",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273ec3d15eab5bd77027abc4b23",
+        "url": "https://open.spotify.com/track/1LPGwuFgIzbJoShfDdw7MY"
+      },
+      {
+        "name": "Gimme Shelter",
+        "artist": "The Rolling Stones",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2732af30c881bb23cfb82a8cf99",
+        "url": "https://open.spotify.com/track/6H3kDe7CGoWYBabAeVWGiD"
+      },
+      {
+        "name": "Heading South",
+        "artist": "Zach Bryan",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273cbb840da8e4bf45aec4503de",
+        "url": "https://open.spotify.com/track/2Dct3GykKZ58hpWRFfe2Qd"
+      },
+      {
+        "name": "The Chain - 2004 Remaster",
+        "artist": "Fleetwood Mac",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273e52a59a28efa4773dd2bfe1b",
+        "url": "https://open.spotify.com/track/5e9TFTbltYBg2xThimr0rU"
+      },
+      {
+        "name": "Blowfish - Lake People Remix",
+        "artist": "Yoko Duo",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273c55f08045aa2b4df4684b59d",
+        "url": "https://open.spotify.com/track/2DKB5n0Nf54tewQaoSzSL3"
+      },
+      {
+        "name": "Howling - Âme Remix",
+        "artist": "Howling",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2731b3262b9b023c904a04b425b",
+        "url": "https://open.spotify.com/track/78jIj6Ph2364zg1ZVIvbIN"
+      },
+      {
+        "name": "Under the Bridge",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2735590b4ee88187cb06a5b102d",
+        "url": "https://open.spotify.com/track/23NPGXlSaIqWzvxIRhM2oG"
+      },
+      {
+        "name": "All that matters",
+        "artist": "Kölsch",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273510fe49b1a60e733c4a37a52",
+        "url": "https://open.spotify.com/track/5hGBJKU8aJaZPVSV7NxoTp"
+      },
+      {
+        "name": "Nevada",
+        "artist": "Kerala Dust",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273a8683b0701eb2b1110695427",
+        "url": "https://open.spotify.com/track/4eP7VbswtkGd5Hlyj4E7Qx"
+      },
+      {
+        "name": "La Ka Rubà",
+        "artist": "NenaHalena",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fdc570b0f94f198ade958782",
+        "url": "https://open.spotify.com/track/4ERTkjp0uNblUwr51tRyXc"
+      },
+      {
+        "name": "Stolen Dance",
+        "artist": "Milky Chance",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b2732001bc1b4dd82d06631fcb9e",
+        "url": "https://open.spotify.com/track/34xGLuxM0rkxhCVyMSqwJO"
+      },
+      {
+        "name": "Super Flu 3 < Isaac",
+        "artist": "Super Flu",
+        "albumArt": "https://i.scdn.co/image/ab67616d0000b273fc055de5cc0b5d5f2ee98caa",
+        "url": "https://open.spotify.com/track/6VItPBZ0fchgQTxgJI50m8"
+      }
+    ]
   }
 }

--- a/src/data/wrapped/2025.json
+++ b/src/data/wrapped/2025.json
@@ -1689,5 +1689,410 @@
     "newCount": 0,
     "returningPct": 100
   },
-  "apiSnapshot": {}
+  "apiSnapshot": {
+    "topArtists": [
+      {
+        "name": "Red Hot Chili Peppers",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "andhim",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Mac Miller",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "The Rolling Stones",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "HVOB",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Super Flu",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Bob Marley & The Wailers",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Fleetwood Mac",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Dire Straits",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Kölsch",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Chet Faker",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Avicii",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Calvin Harris",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Led Zeppelin",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Foals",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Empire Of The Sun",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Milky Chance",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Yoko Duo",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Alec Troniq",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Kanye West",
+        "image": "",
+        "url": ""
+      }
+    ],
+    "topTracks": [
+      {
+        "name": "I Only Smoke When I Drink",
+        "artist": "nimino",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/39glDGcpBhLVMSsQhvtqHR"
+      },
+      {
+        "name": "Always Like This - andhim Remix",
+        "artist": "HVOB",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2Gzl0HAOGySuLysalinVP4"
+      },
+      {
+        "name": "Birthday Card",
+        "artist": "Chet Faker",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3Prt3S5X7nsEKv2VARtKrv"
+      },
+      {
+        "name": "BDE Bonus",
+        "artist": "Mac Miller",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4Pafh2Ndd9O4NgO53rqJxI"
+      },
+      {
+        "name": "Paris - Andhim Remix",
+        "artist": "Groove Armada",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/21RySuiEbDdwCYpcOdqlgn"
+      },
+      {
+        "name": "Close These Curtains - Stimming Remix",
+        "artist": "Yoko Duo",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0ZYQ8J5CmB7EBnFCWwZfaG"
+      },
+      {
+        "name": "Wine & Chocolates - andhim Remix Radio Version",
+        "artist": "Theophilus London",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0qsQZDAZIGsbGmYEMfhTSC"
+      },
+      {
+        "name": "Howling - Âme Remix",
+        "artist": "Howling",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/78jIj6Ph2364zg1ZVIvbIN"
+      },
+      {
+        "name": "Fisher",
+        "artist": "Camel Power Club",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3cY2nHVVX2ZER1ttxGzLav"
+      },
+      {
+        "name": "For A Better Day",
+        "artist": "Avicii",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7kbTZWt7DnzIzbkyzFE1PW"
+      },
+      {
+        "name": "Poppin' Pockets - Remix",
+        "artist": "Grip Grand",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7Gx7T0dusJlzGH2UI3Y4bZ"
+      },
+      {
+        "name": "Beast Of Burden - Remastered 1994",
+        "artist": "The Rolling Stones",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/77oU2rjC5XbjQfNe3bD6so"
+      },
+      {
+        "name": "Could You Be Loved",
+        "artist": "Bob Marley & The Wailers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5O4erNlJ74PIF6kGol1ZrC"
+      },
+      {
+        "name": "Come Together - Remastered 2009",
+        "artist": "The Beatles",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2EqlS6tkEnglzr7tkKAAYD"
+      },
+      {
+        "name": "Simple Man",
+        "artist": "Lynyrd Skynyrd",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1ju7EsSGvRybSNEsRvc7qY"
+      },
+      {
+        "name": "Gooey - Gilligan Moss Remix",
+        "artist": "Glass Animals",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1yshfaUkaAletecfWFVgtS"
+      },
+      {
+        "name": "No Rest for the Wicked - Joris Voorn Remix",
+        "artist": "Lykke Li",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4F9FCeqh9sqCxb6y14yc6h"
+      },
+      {
+        "name": "Oysters In My Pocket",
+        "artist": "Royel Otis",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2B664ulJSVBd6B8SAY3Wux"
+      },
+      {
+        "name": "Feel It Still",
+        "artist": "Portugal. The Man",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6QgjcU0zLnzq5OrUoSZ3OK"
+      },
+      {
+        "name": "Pick Up",
+        "artist": "DJ Koze",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7dFvYtokT2xQH1HvaQgbgY"
+      },
+      {
+        "name": "Electric Feel",
+        "artist": "MGMT",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3FtYbEfBqAlGO46NUDQSAt"
+      },
+      {
+        "name": "Black Friday (pretty like the sun)",
+        "artist": "Lost Frequencies",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4MSj19TwYBLgDFj3ddEeco"
+      },
+      {
+        "name": "Tough As Nails",
+        "artist": "Mindchatter",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2BEDsNidFZnq0Rcnj6WoPO"
+      },
+      {
+        "name": "A Horse with No Name",
+        "artist": "America",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/54eZmuggBFJbV7k248bTTt"
+      },
+      {
+        "name": "Youth",
+        "artist": "Glass Animals",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1LPGwuFgIzbJoShfDdw7MY"
+      },
+      {
+        "name": "Half Mast",
+        "artist": "Empire Of The Sun",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/49Hkgl03InFFqBklOQxunt"
+      },
+      {
+        "name": "The Chain - 2004 Remaster",
+        "artist": "Fleetwood Mac",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5e9TFTbltYBg2xThimr0rU"
+      },
+      {
+        "name": "Pluto - Live",
+        "artist": "Beatenberg",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/59oBTOQ2aidtB5RRbfLdRz"
+      },
+      {
+        "name": "Scar Tissue",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1G391cbiT3v3Cywg8T7DM1"
+      },
+      {
+        "name": "Awake - Agoria Remix",
+        "artist": "Santé",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3oBTlRetzuXuE6mUGnX0Z1"
+      },
+      {
+        "name": "Waste A Moment",
+        "artist": "Kings of Leon",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5LlsD7LdSMkGV4Iu0a2Zq0"
+      },
+      {
+        "name": "Cyclone (The Village Sessions)",
+        "artist": "Sticky Fingers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/53XM8O6sQ4YzCq2jYgXuC6"
+      },
+      {
+        "name": "Birch Tree",
+        "artist": "Foals",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0BPKqNWOKQam19tKWoZQwu"
+      },
+      {
+        "name": "Don't Look Back in Anger - Remastered",
+        "artist": "Oasis",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0UvCh63URrLFcPkKt99hHd"
+      },
+      {
+        "name": "Baba O'Riley",
+        "artist": "The Who",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3qiyyUfYe7CRYLucrPmulD"
+      },
+      {
+        "name": "Sweet Nothing (feat. Florence Welch)",
+        "artist": "Calvin Harris",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/24LS4lQShWyixJ0ZrJXfJ5"
+      },
+      {
+        "name": "Can't Do Without You",
+        "artist": "Caribou",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/35p0Z5yZDogaXoWXhMVEv4"
+      },
+      {
+        "name": "Dancing Again",
+        "artist": "TiMO ODV",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2L0Oi0w0pS3HwltG0pwjUl"
+      },
+      {
+        "name": "My Bed",
+        "artist": "Marbert Rocel",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1N2e9UsOsExRGDVq9IpH24"
+      },
+      {
+        "name": "Shooting Stars",
+        "artist": "Bag Raiders",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0UeYCHOETPfai02uskjJ3x"
+      },
+      {
+        "name": "Good Morning Children",
+        "artist": "Alec Troniq",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7b6gAh0OyzcKsg2i7Tte6u"
+      },
+      {
+        "name": "Can't Tell Me Nothing",
+        "artist": "Kanye West",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0mEdbdeRFQwBhN4xfyIeUM"
+      },
+      {
+        "name": "Franzis",
+        "artist": "FIL BO RIVA",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3w40PaTTE7Ezz2cEXVFLc6"
+      },
+      {
+        "name": "So Good",
+        "artist": "Nosi",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2S9jqUEI9fiDNtSH707KR4"
+      },
+      {
+        "name": "Hate It Or Love It",
+        "artist": "The Game",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2wGSgTmgSF3xjRrHkTc25R"
+      },
+      {
+        "name": "On Melancholy Hill",
+        "artist": "Gorillaz",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0q6LuUqGLUiCPP1cbdwFs3"
+      },
+      {
+        "name": "Snow (Hey Oh)",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2aibwv5hGXSgw7Yru8IYTO"
+      },
+      {
+        "name": "Dreams - 2004 Remaster",
+        "artist": "Fleetwood Mac",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0ofHAoxe9vBkTCp2UQIavz"
+      },
+      {
+        "name": "Boy Boy Boy",
+        "artist": "andhim",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6NFbXVo5s7A4Gq4YPrmHXv"
+      },
+      {
+        "name": "Lady Writer",
+        "artist": "Dire Straits",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2RBcYkonAofm0rYycVrCGt"
+      }
+    ]
+  }
 }

--- a/src/data/wrapped/2026.json
+++ b/src/data/wrapped/2026.json
@@ -1665,5 +1665,411 @@
     "returningCount": 16,
     "newCount": 4,
     "returningPct": 80
+  },
+  "apiSnapshot": {
+    "topArtists": [
+      {
+        "name": "Red Hot Chili Peppers",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "The Rolling Stones",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Led Zeppelin",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Dire Straits",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "HVOB",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Mac Miller",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Fleetwood Mac",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Maribou State",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Bosq",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Fred again..",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "sombr",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Pink Floyd",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "andhim",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "MGMT",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Lynyrd Skynyrd",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "nimino",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Kanye West",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Khruangbin",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Creedence Clearwater Revival",
+        "image": "",
+        "url": ""
+      },
+      {
+        "name": "Queen",
+        "image": "",
+        "url": ""
+      }
+    ],
+    "topTracks": [
+      {
+        "name": "12 to 12",
+        "artist": "sombr",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/05od2qm2MTSKCHxy1GBp5W"
+      },
+      {
+        "name": "Talk of the Town",
+        "artist": "Fred again..",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/26vIeRYFA2Nh56W4jfkjp5"
+      },
+      {
+        "name": "Burning",
+        "artist": "The Whitest Boy Alive",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0QgR03vMDoBoLgcu08EtKl"
+      },
+      {
+        "name": "The Ship",
+        "artist": "Incredible Polo",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1WpCorgdzT5RzNfjbudcms"
+      },
+      {
+        "name": "Oysters In My Pocket",
+        "artist": "Royel Otis",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2B664ulJSVBd6B8SAY3Wux"
+      },
+      {
+        "name": "Electric Feel",
+        "artist": "MGMT",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3FtYbEfBqAlGO46NUDQSAt"
+      },
+      {
+        "name": "No Broke Boys",
+        "artist": "Disco Lines",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3cZajhyr8LmtPfHZ9296tj"
+      },
+      {
+        "name": "Better",
+        "artist": "nimino",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6oUgmZK0McW4706SLJlfDh"
+      },
+      {
+        "name": "Always Like This - andhim Remix",
+        "artist": "HVOB",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2Gzl0HAOGySuLysalinVP4"
+      },
+      {
+        "name": "Paranoid - 2009 Remaster",
+        "artist": "Black Sabbath",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3Jnxngdff0lVu2rza1GVx6"
+      },
+      {
+        "name": "Down Under (feat. Colin Hay)",
+        "artist": "Luude",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7AVyve7cFYTd51ha5i9kE2"
+      },
+      {
+        "name": "Too Sweet",
+        "artist": "Hozier",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/19XpFsce28aByvCC4g89tJ"
+      },
+      {
+        "name": "World Hold On (Children of the Sky) - Radio Edit",
+        "artist": "Bob Sinclar",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3HGwI9qwq5XqBDeZBV3zti"
+      },
+      {
+        "name": "Otherside",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/64BbK9SFKH2jk86U3dGj2P"
+      },
+      {
+        "name": "Lion - Stimming Remix",
+        "artist": "HVOB",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3p6JnYmogd4a1QM0w2npZc"
+      },
+      {
+        "name": "The Spins",
+        "artist": "Mac Miller",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2QGVKiAGTa1YcDqPMhAzF7"
+      },
+      {
+        "name": "Lost",
+        "artist": "Frank Ocean",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3GZD6HmiNUhxXYf8Gch723"
+      },
+      {
+        "name": "By the Way",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1f2V8U1BiWaC9aJWmpOARe"
+      },
+      {
+        "name": "Howling - Âme Remix",
+        "artist": "Howling",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/78jIj6Ph2364zg1ZVIvbIN"
+      },
+      {
+        "name": "Maneater",
+        "artist": "Daryl Hall & John Oates",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7j74lucZ59vqN67Ipe2ZcY"
+      },
+      {
+        "name": "Crucify Your Mind",
+        "artist": "Rodríguez",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2Xn7NadvZ56D0B2D7x2CSL"
+      },
+      {
+        "name": "Start Me Up - Remastered 2009",
+        "artist": "The Rolling Stones",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/7HKez549fwJQDzx3zLjHKC"
+      },
+      {
+        "name": "Hold the Line",
+        "artist": "TOTO",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4aVuWgvD0X63hcOCnZtNFA"
+      },
+      {
+        "name": "A Horse with No Name",
+        "artist": "America",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/54eZmuggBFJbV7k248bTTt"
+      },
+      {
+        "name": "Under the Bridge",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3d9DChrdc6BOeFsbrZ3Is0"
+      },
+      {
+        "name": "Californication",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/48UPSzbZjgc449aqz8bxox"
+      },
+      {
+        "name": "Walking On A Dream",
+        "artist": "Empire Of The Sun",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5r5cp9IpziiIsR6b93vcnQ"
+      },
+      {
+        "name": "Deceptacon",
+        "artist": "Le Tigre",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3pYbQSgggwsaFXDW0u79Yj"
+      },
+      {
+        "name": "Nothing",
+        "artist": "HNNY",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6qwPK5WhplqNcyy1CtnpLT"
+      },
+      {
+        "name": "Hate It Or Love It",
+        "artist": "The Game",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2wGSgTmgSF3xjRrHkTc25R"
+      },
+      {
+        "name": "Feel Good Inc.",
+        "artist": "Gorillaz",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0d28khcov6AiegSCpG5TuT"
+      },
+      {
+        "name": "Go Your Own Way - 2004 Remaster",
+        "artist": "Fleetwood Mac",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/07GvNcU1WdyZJq3XxP0kZa"
+      },
+      {
+        "name": "Long Cool Woman (In a Black Dress) - 1999 Remaster",
+        "artist": "The Hollies",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1J5XEPamp7iQaCU0aFuMnd"
+      },
+      {
+        "name": "Ritmo",
+        "artist": "Raffa Fl",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4FHXsehfIbyPCJLP7fCnIF"
+      },
+      {
+        "name": "Simple Man",
+        "artist": "Lynyrd Skynyrd",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1ju7EsSGvRybSNEsRvc7qY"
+      },
+      {
+        "name": "Mariella",
+        "artist": "Khruangbin",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3dvXRk7TZ929m21p49RR5P"
+      },
+      {
+        "name": "Beast Of Burden - Remastered 1994",
+        "artist": "The Rolling Stones",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/77oU2rjC5XbjQfNe3bD6so"
+      },
+      {
+        "name": "Scar Tissue",
+        "artist": "Red Hot Chili Peppers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1G391cbiT3v3Cywg8T7DM1"
+      },
+      {
+        "name": "Could You Be Loved",
+        "artist": "Bob Marley & The Wailers",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5O4erNlJ74PIF6kGol1ZrC"
+      },
+      {
+        "name": "I Remember Everything (feat. Kacey Musgraves)",
+        "artist": "Zach Bryan",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4KULAymBBJcPRpk1yO4dOG"
+      },
+      {
+        "name": "Wine & Chocolates - andhim Remix Radio Version",
+        "artist": "Theophilus London",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/0qsQZDAZIGsbGmYEMfhTSC"
+      },
+      {
+        "name": "Today",
+        "artist": "Zero 7",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/4lK8Vtfw9SOpL1WCoaccnK"
+      },
+      {
+        "name": "Hot Blooded",
+        "artist": "New Constellations",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1ElySIlHwm1HX7sUjAZZnp"
+      },
+      {
+        "name": "Outrun",
+        "artist": "De Hofnar",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/6krMxNzBc7ryjqTGrI8Cv0"
+      },
+      {
+        "name": "For What It's Worth",
+        "artist": "Buffalo Springfield",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1qRA5BS78u3gME0loMl9AA"
+      },
+      {
+        "name": "Miss You - Remastered",
+        "artist": "The Rolling Stones",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/3hJLKtTpgct9Y9wKww0BiR"
+      },
+      {
+        "name": "For Whom The Bell Tolls - Remastered",
+        "artist": "Metallica",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/2dXsILW8gzkosqleHAvl0v"
+      },
+      {
+        "name": "More Than a Feeling",
+        "artist": "Boston",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/1QEEqeFIZktqIpPI4jSVSF"
+      },
+      {
+        "name": "Stairway to Heaven - Remaster",
+        "artist": "Led Zeppelin",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/12wlYeErSUNGg1B5d64077"
+      },
+      {
+        "name": "Something Good",
+        "artist": "alt-J",
+        "albumArt": "",
+        "url": "https://open.spotify.com/track/5UqHgJxYCMQraYuqeEOvtr"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Wrapped year pages had no image URLs — artist photos and album art were silently skipped by the rendering components
- `[year].astro` already had an `apiSnapshot` merge mechanism to backfill images but it was never populated
- Added `scripts/enrich-wrapped-images.mjs` to call the Spotify search API and write image URLs into each year's `apiSnapshot`

## Enrichment status
| Years | Artists | Tracks | Status |
|-------|---------|--------|--------|
| 2018–2022, 2024 | 20/20 | 47–50/50 | Complete |
| 2023, 2025, 2026 | 0/20 | 0/50 | Rate limited — re-run tomorrow |

Re-run with: `node scripts/enrich-wrapped-images.mjs` (auto-skips already-enriched years)

## Test plan
- [ ] Visit `/wrapped/2024` — artist circles and album art squares should be visible
- [ ] Visit `/wrapped/2018` — confirm historical years also show images
- [ ] Confirm no broken image placeholders on enriched years
- [ ] After re-running script for 2023/2025/2026, verify those pages too

🤖 Generated with [Claude Code](https://claude.com/claude-code)