### PR TITLE
fix: theme toggle system mode + wrapped CI

### DIFF
--- a/.github/workflows/update-wrapped.yml
+++ b/.github/workflows/update-wrapped.yml
@@ -35,10 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.PORTFOLIO_PAT }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - run: npm ci
 

--- a/src/components/common/ApplyColorMode.astro
+++ b/src/components/common/ApplyColorMode.astro
@@ -4,14 +4,13 @@
 
 <script is:inline>
   (function () {
-    const stored = localStorage.getItem("theme");
-    const prefersDark = window.matchMedia(
+    var stored = localStorage.getItem("theme");
+    var prefersDark = window.matchMedia(
       "(prefers-color-scheme: dark)",
     ).matches;
-    if (stored === "dark" || (!stored && prefersDark)) {
-      document.documentElement.classList.add("dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-    }
+    var dark =
+      stored === "dark" || (stored !== "light" && prefersDark);
+    document.documentElement.classList.toggle("dark", dark);
+    document.documentElement.dataset.theme = stored || "system";
   })();
 </script>

--- a/src/components/common/ThemeToggle.astro
+++ b/src/components/common/ThemeToggle.astro
@@ -3,11 +3,12 @@
 
 <button
   type="button"
-  aria-label="Toggle dark mode"
+  aria-label="Toggle theme"
   class="theme-toggle p-2 rounded-lg transition-colors hover:text-ember-500"
 >
+  <!-- Sun — shown in dark mode (click to go to system) -->
   <svg
-    class="hidden dark:block w-5 h-5"
+    class="theme-icon-sun hidden w-5 h-5"
     fill="none"
     viewBox="0 0 24 24"
     stroke-width="2"
@@ -19,8 +20,9 @@
       d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"
     ></path>
   </svg>
+  <!-- Moon — shown in light mode (click to go to dark) -->
   <svg
-    class="block dark:hidden w-5 h-5"
+    class="theme-icon-moon hidden w-5 h-5"
     fill="none"
     viewBox="0 0 24 24"
     stroke-width="2"
@@ -32,13 +34,78 @@
       d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 006.002-2.998z"
     ></path>
   </svg>
+  <!-- Monitor — shown in system mode -->
+  <svg
+    class="theme-icon-system hidden w-5 h-5"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="2"
+    stroke="currentColor"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25A2.25 2.25 0 015.25 3h13.5A2.25 2.25 0 0121 5.25z"
+    ></path>
+  </svg>
 </button>
 
 <script>
-  document.querySelectorAll(".theme-toggle").forEach((toggle) => {
-    toggle.addEventListener("click", () => {
-      const isDark = document.documentElement.classList.toggle("dark");
-      localStorage.setItem("theme", isDark ? "dark" : "light");
+  const CYCLE = ["system", "dark", "light"] as const;
+  type Theme = (typeof CYCLE)[number];
+
+  function getTheme(): Theme {
+    const stored = localStorage.getItem("theme");
+    if (stored === "dark" || stored === "light") return stored;
+    return "system";
+  }
+
+  function applyTheme(theme: Theme) {
+    const prefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches;
+    const dark = theme === "dark" || (theme === "system" && prefersDark);
+    document.documentElement.classList.toggle("dark", dark);
+    document.documentElement.dataset.theme = theme;
+  }
+
+  function updateIcons(theme: Theme) {
+    document.querySelectorAll(".theme-icon-sun").forEach((el) => {
+      (el as HTMLElement).classList.toggle("hidden", theme !== "dark");
     });
-  });
+    document.querySelectorAll(".theme-icon-moon").forEach((el) => {
+      (el as HTMLElement).classList.toggle("hidden", theme !== "light");
+    });
+    document.querySelectorAll(".theme-icon-system").forEach((el) => {
+      (el as HTMLElement).classList.toggle("hidden", theme !== "system");
+    });
+  }
+
+  function init() {
+    const theme = getTheme();
+    updateIcons(theme);
+
+    document.querySelectorAll(".theme-toggle").forEach((toggle) => {
+      toggle.addEventListener("click", () => {
+        const current = getTheme();
+        const next = CYCLE[(CYCLE.indexOf(current) + 1) % CYCLE.length];
+        if (next === "system") {
+          localStorage.removeItem("theme");
+        } else {
+          localStorage.setItem("theme", next);
+        }
+        applyTheme(next);
+        updateIcons(next);
+      });
+    });
+
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", () => {
+        if (getTheme() === "system") applyTheme("system");
+      });
+  }
+
+  init();
+  document.addEventListener("astro:after-swap", init);
 </script>

--- a/src/components/common/ThemeToggle.astro
+++ b/src/components/common/ThemeToggle.astro
@@ -81,29 +81,38 @@
     });
   }
 
+  function handleClick() {
+    const current = getTheme();
+    const next = CYCLE[(CYCLE.indexOf(current) + 1) % CYCLE.length];
+    if (next === "system") {
+      localStorage.removeItem("theme");
+    } else {
+      localStorage.setItem("theme", next);
+    }
+    applyTheme(next);
+    updateIcons(next);
+  }
+
+  function handleSystemChange() {
+    if (getTheme() === "system") applyTheme("system");
+  }
+
+  let cleanups: (() => void)[] = [];
+
   function init() {
-    const theme = getTheme();
-    updateIcons(theme);
+    cleanups.forEach((fn) => fn());
+    cleanups = [];
+
+    updateIcons(getTheme());
 
     document.querySelectorAll(".theme-toggle").forEach((toggle) => {
-      toggle.addEventListener("click", () => {
-        const current = getTheme();
-        const next = CYCLE[(CYCLE.indexOf(current) + 1) % CYCLE.length];
-        if (next === "system") {
-          localStorage.removeItem("theme");
-        } else {
-          localStorage.setItem("theme", next);
-        }
-        applyTheme(next);
-        updateIcons(next);
-      });
+      toggle.addEventListener("click", handleClick);
+      cleanups.push(() => toggle.removeEventListener("click", handleClick));
     });
 
-    window
-      .matchMedia("(prefers-color-scheme: dark)")
-      .addEventListener("change", () => {
-        if (getTheme() === "system") applyTheme("system");
-      });
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    mq.addEventListener("change", handleSystemChange);
+    cleanups.push(() => mq.removeEventListener("change", handleSystemChange));
   }
 
   init();


### PR DESCRIPTION
## Summary
- **Theme toggle**: Now cycles system → dark → light instead of just dark/light. System mode follows OS `prefers-color-scheme` and updates live when the OS theme changes. Clearing `localStorage` when returning to system mode so it never gets stuck overriding the OS setting.
- **Wrapped CI**: `update` job was missing `submodules: recursive` and `PORTFOLIO_PAT` on checkout, causing the build to fail every week (`ENOENT: content/portfolio/projects/*.md`). Also bumped node 20 → 22.

## Test plan
- [ ] Open site, verify theme defaults to OS preference (no prior localStorage)
- [ ] Click toggle: should cycle system (monitor icon) → dark (sun) → light (moon) → system
- [ ] In system mode, switch OS theme — site should follow immediately
- [ ] After clicking to dark/light, reload — should persist the override
- [ ] After cycling back to system, reload — should follow OS again
- [ ] Trigger Update Wrapped Data workflow manually — verify both jobs succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)